### PR TITLE
docs: useUsers() hooks の使い方を追加

### DIFF
--- a/docs/world-components/components/index.md
+++ b/docs/world-components/components/index.md
@@ -201,3 +201,50 @@ function MyPlatform() {
 :::note[使用先]
 このフックは xrift-frontend（プラットフォーム）側での使用を想定しています。ワールド開発者は `SpawnPoint` コンポーネントを使用してください。
 :::
+
+---
+
+### useUsers
+
+ワールドに参加しているユーザー情報を取得するフックです。自分自身（ローカルユーザー）と他の参加者（リモートユーザー）の情報にアクセスできます。
+
+```tsx
+import { useUsers } from '@xrift/world-components';
+
+function ParticipantCount() {
+  const { localUser, remoteUsers } = useUsers();
+
+  const totalCount = (localUser ? 1 : 0) + remoteUsers.length;
+
+  return (
+    <div>
+      <p>参加者数: {totalCount}人</p>
+    </div>
+  );
+}
+```
+
+#### 戻り値
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `localUser` | `User \| null` | 自分自身のユーザー情報 |
+| `remoteUsers` | `User[]` | 他の参加者のユーザー情報の配列 |
+
+#### User 型
+
+```typescript
+interface User {
+  id: string;              // ユーザーID
+  displayName: string;     // 表示名
+  avatarUrl: string | null; // アバターアイコンURL
+  isGuest: boolean;        // ゲストかどうか
+}
+```
+
+#### ユースケース
+
+- **参加者数の表示**: ワールド内の参加人数をリアルタイムで表示
+- **参加者リストの表示**: 参加者一覧UIを作成
+- **ユーザーに応じた演出**: ユーザー数に応じてワールドの演出を変更
+- **ゲストと認証ユーザーの区別**: `isGuest` を使って権限や表示を分ける


### PR DESCRIPTION
## Summary
- `@xrift/world-components@0.13.0` で追加された `useUsers()` hooks のドキュメントを追加
- 基本的な使い方、型定義、ユースケースを記載

## 追加した内容
- `localUser` と `remoteUsers` の取得方法
- `User` 型定義
- ユースケース（参加者数表示、参加者リスト、ユーザーに応じた演出、ゲスト判定）

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)