### PR TITLE
docs: ワールド物理設定（physics）のドキュメント追加

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -35,6 +35,7 @@ sidebar_position: 2
 | `thumbnailPath` | string | サムネイル画像のパス（`distDir` からの相対パス） |
 | `buildCommand` | string | アップロード前に実行するビルドコマンド |
 | `ignore` | string[] | アップロードから除外するファイルの glob パターン |
+| `physics` | object | ワールドの物理設定 |
 
 ## 各項目の詳細
 
@@ -104,6 +105,64 @@ sidebar_position: 2
       "**/Thumbs.db",
       "**/*.map"
     ]
+  }
+}
+```
+
+### physics
+
+ワールドの物理動作をカスタマイズできます。
+
+| 設定 | 型 | デフォルト | 説明 |
+|------|-----|---------|------|
+| `gravity` | number | 9.81 | 重力の強さ（正の値、地球=9.81、月=1.62） |
+| `allowInfiniteJump` | boolean | true | 無限ジャンプを許可するか |
+
+#### 基本設定
+
+```json
+{
+  "world": {
+    "physics": {
+      "gravity": 9.81,
+      "allowInfiniteJump": true
+    }
+  }
+}
+```
+
+#### アスレチックワールド（無限ジャンプ禁止）
+
+```json
+{
+  "world": {
+    "physics": {
+      "allowInfiniteJump": false
+    }
+  }
+}
+```
+
+#### 低重力ワールド（月の重力）
+
+```json
+{
+  "world": {
+    "physics": {
+      "gravity": 1.62
+    }
+  }
+}
+```
+
+#### 高重力ワールド（木星の重力）
+
+```json
+{
+  "world": {
+    "physics": {
+      "gravity": 24.79
+    }
   }
 }
 ```


### PR DESCRIPTION
## Summary
- `xrift.json`の`world.physics`セクションでワールドの物理設定をカスタマイズできる機能のドキュメントを追加
- `gravity`（重力の強さ）と`allowInfiniteJump`（無限ジャンプ許可）の設定項目を追加
- 各ユースケースに応じた設定例（基本、アスレチック、低重力、高重力）を追加

## Test plan
- [ ] ドキュメントの表示が正しいか確認
- [ ] コード例が正しくレンダリングされるか確認

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)