### PR TITLE
docs: LAYERS 定数のドキュメントを追加

### DIFF
--- a/docs/world-components/components/index.md
+++ b/docs/world-components/components/index.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # API リファレンス
 
-xrift-world-components で提供されるコンポーネントとフックの一覧です。
+xrift-world-components で提供されるコンポーネント、フック、定数の一覧です。
 
 ## コンポーネント
 
@@ -653,3 +653,34 @@ function DistanceLine({ targetUser, getMovement, getLocalMovement }) {
 :::note[remoteUsers の更新タイミング]
 `remoteUsers` 配列はユーザーの参加/離脱時のみ更新されます。ユーザーの位置情報の変化では再レンダリングは発生しません。位置情報は常に `getMovement()` を使用して取得してください。
 :::
+
+---
+
+## 定数
+
+### LAYERS
+
+Three.js のレイヤーシステムを活用した定数です。カメラやRaycasterのレイヤー設定に使用します。
+
+```typescript
+import { LAYERS } from '@xrift/world-components';
+```
+
+| 定数名 | 値 | 説明 |
+|--------|-----|------|
+| `LAYERS.DEFAULT` | `0` | デフォルトレイヤー（すべてのオブジェクトが初期状態で属する） |
+| `LAYERS.FIRST_PERSON_ONLY` | `9` | 一人称視点のみ表示（VRMFirstPerson用） |
+| `LAYERS.THIRD_PERSON_ONLY` | `10` | 三人称視点のみ表示（VRMFirstPerson用） |
+| `LAYERS.INTERACTABLE` | `11` | インタラクト可能オブジェクト（Raycast対象） |
+
+#### 関連する型
+
+```typescript
+type LayerName = 'DEFAULT' | 'FIRST_PERSON_ONLY' | 'THIRD_PERSON_ONLY' | 'INTERACTABLE';
+type LayerNumber = 0 | 9 | 10 | 11;
+```
+
+#### ユースケース
+
+- Raycasterでインタラクション対象を検出する際のレイヤー設定
+- VRモードでの一人称/三人称の表示切り替え

--- a/i18n/en/docusaurus-plugin-content-docs/current/world-components/components/index.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/world-components/components/index.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # API Reference
 
-A list of components and hooks provided by xrift-world-components.
+A list of components, hooks, and constants provided by xrift-world-components.
 
 ## Components
 
@@ -653,3 +653,34 @@ function DistanceLine({ targetUser, getMovement, getLocalMovement }) {
 :::note[remoteUsers Update Timing]
 The `remoteUsers` array is updated only when users join or leave. Changes in user positions do not trigger re-renders. Always use `getMovement()` to retrieve position information.
 :::
+
+---
+
+## Constants
+
+### LAYERS
+
+Constants utilizing Three.js's layer system. Used for configuring layers on cameras and Raycasters.
+
+```typescript
+import { LAYERS } from '@xrift/world-components';
+```
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `LAYERS.DEFAULT` | `0` | Default layer (all objects belong to this layer initially) |
+| `LAYERS.FIRST_PERSON_ONLY` | `9` | First-person view only (for VRMFirstPerson) |
+| `LAYERS.THIRD_PERSON_ONLY` | `10` | Third-person view only (for VRMFirstPerson) |
+| `LAYERS.INTERACTABLE` | `11` | Interactable objects (Raycast targets) |
+
+#### Related Types
+
+```typescript
+type LayerName = 'DEFAULT' | 'FIRST_PERSON_ONLY' | 'THIRD_PERSON_ONLY' | 'INTERACTABLE';
+type LayerNumber = 0 | 9 | 10 | 11;
+```
+
+#### Use Cases
+
+- Setting layers for detecting interaction targets with Raycaster
+- Switching between first-person/third-person views in VR mode


### PR DESCRIPTION
## Summary
- `@xrift/world-components@0.22.1` で追加された `LAYERS` 定数のドキュメントを追加
- 日本語・英語の両方のAPIリファレンスに記載
- 定数一覧、関連する型（`LayerName`, `LayerNumber`）、ユースケースを記載

Closes #21

## Test plan
- [ ] 日本語版のAPIリファレンスページで LAYERS セクションが正しく表示されること
- [ ] 英語版のAPIリファレンスページで Constants セクションが正しく表示されること
- [ ] テーブルのフォーマットが崩れていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)