### PR TITLE
docs: DevEnvironment に使用場所の注意書きを追加

### DIFF
--- a/docs/world-components/components/index.md
+++ b/docs/world-components/components/index.md
@@ -406,6 +406,10 @@ createRoot(rootElement).render(
 | Space / E | ジャンプ |
 | ESC | ポインターロック解除 |
 
+:::caution[使用場所について]
+このコンポーネントはワールド開発プロジェクトで `npm run dev` を実行した際のローカル確認用です。`World.tsx` などの実際のワールドコンテンツ内では使用しないでください。
+:::
+
 :::note[前提条件]
 `@react-three/rapier`（`^2.0.0`）のインストールが必要です（optional peerDependency）。
 :::

--- a/i18n/en/docusaurus-plugin-content-docs/current/world-components/components/index.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/world-components/components/index.md
@@ -406,6 +406,10 @@ createRoot(rootElement).render(
 | Space / E | Jump |
 | ESC | Release pointer lock |
 
+:::caution[Usage]
+This component is for local preview when running `npm run dev` in a world development project. Do not use it inside actual world content such as `World.tsx`.
+:::
+
 :::note[Prerequisites]
 Installation of `@react-three/rapier` (`^2.0.0`) is required (optional peerDependency).
 :::


### PR DESCRIPTION
## Summary
- DevEnvironment コンポーネントに `:::caution` で使用場所の注意書きを追加
- `npm run dev` でのローカル確認用であり、`World.tsx` 等のワールドコンテンツ内では使用しない旨を明記
- 日本語・英語の両方に追記

## Test plan
- [ ] caution アドモニションの表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)