### PR TITLE
docs: DevEnvironment の注意書きを説明文直後に移動

### DIFF
--- a/docs/world-components/components/index.md
+++ b/docs/world-components/components/index.md
@@ -353,6 +353,10 @@ export const MyWorld = () => {
 
 ローカル開発用の環境を提供するコンポーネントです。ワールドテンプレートの `dev.tsx` で使用します。
 
+:::caution[使用場所について]
+このコンポーネントはワールド開発プロジェクトで `npm run dev` を実行した際のローカル確認用です。`World.tsx` などの実際のワールドコンテンツ内では使用しないでください。
+:::
+
 ```tsx
 import { DevEnvironment, XRiftProvider } from '@xrift/world-components'
 import { World } from './World'
@@ -405,10 +409,6 @@ createRoot(rootElement).render(
 | WASD / 矢印キー | 移動 |
 | Space / E | ジャンプ |
 | ESC | ポインターロック解除 |
-
-:::caution[使用場所について]
-このコンポーネントはワールド開発プロジェクトで `npm run dev` を実行した際のローカル確認用です。`World.tsx` などの実際のワールドコンテンツ内では使用しないでください。
-:::
 
 :::note[前提条件]
 `@react-three/rapier`（`^2.0.0`）のインストールが必要です（optional peerDependency）。

--- a/i18n/en/docusaurus-plugin-content-docs/current/world-components/components/index.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/world-components/components/index.md
@@ -353,6 +353,10 @@ export const MyWorld = () => {
 
 A component that provides a local development environment. Used in the world template's `dev.tsx`.
 
+:::caution[Usage]
+This component is for local preview when running `npm run dev` in a world development project. Do not use it inside actual world content such as `World.tsx`.
+:::
+
 ```tsx
 import { DevEnvironment, XRiftProvider } from '@xrift/world-components'
 import { World } from './World'
@@ -405,10 +409,6 @@ createRoot(rootElement).render(
 | WASD / Arrow Keys | Movement |
 | Space / E | Jump |
 | ESC | Release pointer lock |
-
-:::caution[Usage]
-This component is for local preview when running `npm run dev` in a world development project. Do not use it inside actual world content such as `World.tsx`.
-:::
 
 :::note[Prerequisites]
 Installation of `@react-three/rapier` (`^2.0.0`) is required (optional peerDependency).


### PR DESCRIPTION
## Summary
- DevEnvironment の `:::caution` 注意書きをセクション末尾から説明文直後（コード例の前）に移動
- コンポーネントを見た際にまず注意書きが目に入るように配置を変更

## Test plan
- [ ] caution アドモニションが説明文の直後に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)