### PR TITLE
docs: API キーの取得先リンクを追加

### DIFF
--- a/docs/public-api/v1.md
+++ b/docs/public-api/v1.md
@@ -17,6 +17,8 @@ sidebar_position: 1
 | API キー | `Authorization: Bearer xrift_sk_xxx` | サードパーティ開発者向け（スコープ + レート制限あり） |
 | CLI トークン | `Authorization: Bearer xrf_xxx` | CLI / 内部ツール向け（全権限、レート制限なし） |
 
+API キーは [XRift の設定画面](https://app.xrift.net/settings) から取得できます。
+
 - API キーは `xrift_sk_` プレフィックスで識別されます
 - CLI トークンは `xrf_` プレフィックスで識別されます
 - いずれの形式にも該当しないトークンは `401` エラーになります

--- a/i18n/en/docusaurus-plugin-content-docs/current/public-api/v1.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/public-api/v1.md
@@ -17,6 +17,8 @@ Two authentication methods are supported. Send the token via the `Authorization`
 | API Key | `Authorization: Bearer xrift_sk_xxx` | For third-party developers (scoped + rate limited) |
 | CLI Token | `Authorization: Bearer xrf_xxx` | For CLI / internal tools (full access, no rate limit) |
 
+You can obtain an API key from the [XRift settings page](https://app.xrift.net/settings).
+
 - API keys are identified by the `xrift_sk_` prefix
 - CLI tokens are identified by the `xrf_` prefix
 - Tokens that don't match either format will return a `401` error


### PR DESCRIPTION
## Summary
- 認証セクションに API キーの取得先として XRift 設定画面 (https://app.xrift.net/settings) へのリンクを追加
- 日本語・英語両方に反映

🤖 Generated with [Claude Code](https://claude.com/claude-code)