### PR TITLE
docs: useTeleport フックのドキュメント追加

### DIFF
--- a/docs/world-components/components/index.md
+++ b/docs/world-components/components/index.md
@@ -723,6 +723,72 @@ function DistanceLine({ targetUser, getMovement, getLocalMovement }) {
 
 ---
 
+### useTeleport
+
+プレイヤーを指定した座標に瞬間移動させるフックです。ポータル、エレベーター、ワープゾーンなどのユースケースに対応します。
+
+```tsx
+import { useTeleport } from '@xrift/world-components';
+
+function MyComponent() {
+  const { teleport } = useTeleport();
+
+  const handleTeleport = useCallback(() => {
+    teleport({ position: [50, 0, 30], yaw: 180 });
+  }, [teleport]);
+}
+```
+
+#### API
+
+```typescript
+interface TeleportDestination {
+  position: [number, number, number]
+  yaw?: number // 度数法（0-360）省略時は現在の向きを維持
+}
+
+const { teleport } = useTeleport()
+```
+
+#### パラメータ（TeleportDestination）
+
+| パラメータ | 型 | 必須 | 説明 |
+|-----------|-----|------|------|
+| `position` | `[number, number, number]` | Yes | テレポート先の座標 [x, y, z] |
+| `yaw` | `number` | No | テレポート後の向き（度数法 0-360）。省略時は現在の向きを維持 |
+
+#### 使用例
+
+##### ポータルでテレポート
+
+```tsx
+import { useTeleport, Interactable } from '@xrift/world-components'
+import { useCallback } from 'react'
+
+function MyWorld() {
+  const { teleport } = useTeleport()
+
+  const handlePortal = useCallback(() => {
+    teleport({ position: [50, 0, 30], yaw: 180 })
+  }, [teleport])
+
+  return (
+    <Interactable id="portal" onInteract={handlePortal}>
+      <mesh>
+        <torusGeometry />
+        <meshStandardMaterial color="purple" />
+      </mesh>
+    </Interactable>
+  )
+}
+```
+
+:::tip[yaw の省略]
+`yaw` を省略するとテレポート後もプレイヤーの現在の向きが維持されます。特定の方向を向かせたい場合のみ指定してください。
+:::
+
+---
+
 ## 定数
 
 ### LAYERS

--- a/i18n/en/docusaurus-plugin-content-docs/current/world-components/components/index.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/world-components/components/index.md
@@ -723,6 +723,72 @@ The `remoteUsers` array is updated only when users join or leave. Changes in use
 
 ---
 
+### useTeleport
+
+A hook for teleporting the player to a specified position. Supports use cases such as portals, elevators, and warp zones.
+
+```tsx
+import { useTeleport } from '@xrift/world-components';
+
+function MyComponent() {
+  const { teleport } = useTeleport();
+
+  const handleTeleport = useCallback(() => {
+    teleport({ position: [50, 0, 30], yaw: 180 });
+  }, [teleport]);
+}
+```
+
+#### API
+
+```typescript
+interface TeleportDestination {
+  position: [number, number, number]
+  yaw?: number // Degrees (0-360). Maintains current orientation when omitted
+}
+
+const { teleport } = useTeleport()
+```
+
+#### Parameters (TeleportDestination)
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `position` | `[number, number, number]` | Yes | Teleport destination coordinates [x, y, z] |
+| `yaw` | `number` | No | Orientation after teleport (degrees 0-360). Maintains current orientation when omitted |
+
+#### Usage Example
+
+##### Teleport with a Portal
+
+```tsx
+import { useTeleport, Interactable } from '@xrift/world-components'
+import { useCallback } from 'react'
+
+function MyWorld() {
+  const { teleport } = useTeleport()
+
+  const handlePortal = useCallback(() => {
+    teleport({ position: [50, 0, 30], yaw: 180 })
+  }, [teleport])
+
+  return (
+    <Interactable id="portal" onInteract={handlePortal}>
+      <mesh>
+        <torusGeometry />
+        <meshStandardMaterial color="purple" />
+      </mesh>
+    </Interactable>
+  )
+}
+```
+
+:::tip[Omitting yaw]
+When `yaw` is omitted, the player's current orientation is maintained after teleporting. Only specify it when you want the player to face a specific direction.
+:::
+
+---
+
 ## Constants
 
 ### LAYERS


### PR DESCRIPTION
## Summary
- `@xrift/world-components` v0.26.1 で追加された `useTeleport` フックの API リファレンスを追加
- 日本語・英語の両方のドキュメントを更新
- API 定義、パラメータ説明、ポータルを使った使用例を記載

Closes #33

## Test plan
- [ ] 日本語ドキュメント（`docs/world-components/components/index.md`）に useTeleport セクションが正しく表示されること
- [ ] 英語ドキュメント（`i18n/en/.../index.md`）に useTeleport セクションが正しく表示されること
- [ ] コードブロックのシンタックスハイライトが正しいこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)