### PR TITLE
docs: useTeleport の説明を明確化

### DIFF
--- a/docs/world-components/components/index.md
+++ b/docs/world-components/components/index.md
@@ -725,7 +725,7 @@ function DistanceLine({ targetUser, getMovement, getLocalMovement }) {
 
 ### useTeleport
 
-プレイヤーを指定した座標に瞬間移動させるフックです。ポータル、エレベーター、ワープゾーンなどのユースケースに対応します。
+自分自身のアバターを指定した座標に瞬間移動させるフックです。ポータル、エレベーター、ワープゾーンなどのユースケースに対応します。
 
 ```tsx
 import { useTeleport } from '@xrift/world-components';

--- a/i18n/en/docusaurus-plugin-content-docs/current/world-components/components/index.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/world-components/components/index.md
@@ -725,7 +725,7 @@ The `remoteUsers` array is updated only when users join or leave. Changes in use
 
 ### useTeleport
 
-A hook for teleporting the player to a specified position. Supports use cases such as portals, elevators, and warp zones.
+A hook for teleporting your own avatar to a specified position. Supports use cases such as portals, elevators, and warp zones.
 
 ```tsx
 import { useTeleport } from '@xrift/world-components';


### PR DESCRIPTION
## Summary
- `useTeleport` の説明を「自分自身のアバターを移動させる」と明確化
- 日本語・英語の両方を修正

## Test plan
- [ ] 日本語ドキュメントの useTeleport 説明文が正しく表示されること
- [ ] 英語ドキュメントの useTeleport 説明文が正しく表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)