### PR TITLE
docs: Portal コンポーネント、useInstance/useWorld フックのドキュメント追加

### DIFF
--- a/docs/world-components/components/index.md
+++ b/docs/world-components/components/index.md
@@ -416,6 +416,40 @@ createRoot(rootElement).render(
 
 ---
 
+### Portal
+
+他のインスタンスへの移動ポータルを表示するコンポーネントです。渦巻きシェーダーエフェクト、移動先のサムネイル・ワールド名・インスタンス名・人数、パーティクル、グロー、クリック可能な台座で構成されます。
+
+`instanceId` を指定すると、対象インスタンスの情報を自動取得して表示します。台座をクリックすると確認モーダル（useConfirm）を経て対象インスタンスへ遷移します。
+
+```tsx
+import { Portal } from '@xrift/world-components'
+
+function MyWorld() {
+  return (
+    <Portal
+      instanceId="target-instance-id"
+      position={[5, 0, 0]}
+      rotation={[0, Math.PI / 2, 0]}
+    />
+  )
+}
+```
+
+#### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `instanceId` | `string` | - | 移動先のインスタンスID（必須） |
+| `position` | `[number, number, number]` | `[0, 0, 0]` | ポータルの座標 |
+| `rotation` | `[number, number, number]` | `[0, 0, 0]` | ポータルの回転 |
+
+:::note[内部で使用するフック]
+`Portal` は内部で `useInstance` フックを使用してインスタンス情報の取得と遷移を行っています。
+:::
+
+---
+
 ## フック
 
 ### useInstanceState
@@ -786,6 +820,104 @@ function MyWorld() {
 :::tip[yaw の省略]
 `yaw` を省略するとテレポート後もプレイヤーの現在の向きが維持されます。特定の方向を向かせたい場合のみ指定してください。
 :::
+
+---
+
+### useInstance
+
+インスタンス情報の取得と確認付き遷移を提供するフックです。内部で `useConfirm` を使い、遷移前に確認モーダルを表示します。
+
+```tsx
+import { useInstance } from '@xrift/world-components'
+
+function MyComponent() {
+  const { info, navigateWithConfirm } = useInstance('target-instance-id')
+
+  if (!info) return null
+
+  return (
+    <mesh onClick={navigateWithConfirm}>
+      {/* インスタンス名: {info.name} */}
+    </mesh>
+  )
+}
+```
+
+#### 引数
+
+| 引数 | Type | Description |
+|-----|------|-------------|
+| `instanceId` | `string` | 取得するインスタンスのID |
+
+#### 戻り値
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `info` | `InstanceInfo \| null` | インスタンス情報（取得前は null） |
+| `navigateWithConfirm` | `() => Promise<void>` | 確認モーダル付きでインスタンスへ遷移 |
+
+#### InstanceInfo 型
+
+| フィールド | Type | Description |
+|-----------|------|-------------|
+| `id` | `string` | インスタンスID |
+| `name` | `string` | インスタンス名 |
+| `description` | `string \| null` | 説明 |
+| `currentUsers` | `number` | 現在のユーザー数 |
+| `maxCapacity` | `number` | 最大収容人数 |
+| `isPublic` | `boolean` | 公開かどうか |
+| `allowGuests` | `boolean` | ゲスト許可 |
+| `owner` | `{ id, displayName, userIconUrl? }` | オーナー情報（任意） |
+| `world` | `WorldInfo` | 所属ワールドの情報 |
+
+---
+
+### useWorld
+
+ワールド情報の取得を提供するフックです。
+
+```tsx
+import { useWorld } from '@xrift/world-components'
+
+function MyComponent() {
+  const { info } = useWorld('target-world-id')
+
+  if (!info) return null
+
+  return (
+    <mesh>
+      {/* ワールド名: {info.name} */}
+    </mesh>
+  )
+}
+```
+
+#### 引数
+
+| 引数 | Type | Description |
+|-----|------|-------------|
+| `worldId` | `string` | 取得するワールドのID |
+
+#### 戻り値
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `info` | `WorldInfo \| null` | ワールド情報（取得前は null） |
+
+#### WorldInfo 型
+
+| フィールド | Type | Description |
+|-----------|------|-------------|
+| `id` | `string` | ワールドID |
+| `name` | `string` | ワールド名 |
+| `description` | `string \| null` | 説明 |
+| `thumbnailUrl` | `string \| null` | サムネイルURL |
+| `isPublic` | `boolean` | 公開かどうか |
+| `instanceCount` | `number` | インスタンス数 |
+| `totalVisitCount` | `number` | 総訪問数 |
+| `uniqueVisitorCount` | `number` | ユニーク訪問者数 |
+| `favoriteCount` | `number` | お気に入り数 |
+| `owner` | `{ id, displayName, userIconUrl? }` | オーナー情報（任意） |
 
 ---
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/world-components/components/index.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/world-components/components/index.md
@@ -416,6 +416,40 @@ Installation of `@react-three/rapier` (`^2.0.0`) is required (optional peerDepen
 
 ---
 
+### Portal
+
+A component that displays a portal for moving to another instance. It consists of a swirl shader effect, destination thumbnail/world name/instance name/user count, particles, glow, and a clickable pedestal.
+
+When `instanceId` is specified, it automatically fetches and displays information about the target instance. Clicking the pedestal triggers a confirmation modal (useConfirm) before transitioning to the target instance.
+
+```tsx
+import { Portal } from '@xrift/world-components'
+
+function MyWorld() {
+  return (
+    <Portal
+      instanceId="target-instance-id"
+      position={[5, 0, 0]}
+      rotation={[0, Math.PI / 2, 0]}
+    />
+  )
+}
+```
+
+#### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `instanceId` | `string` | - | ID of the destination instance (Required) |
+| `position` | `[number, number, number]` | `[0, 0, 0]` | Position of the portal |
+| `rotation` | `[number, number, number]` | `[0, 0, 0]` | Rotation of the portal |
+
+:::note[Internally Used Hook]
+`Portal` internally uses the `useInstance` hook to fetch instance information and handle navigation.
+:::
+
+---
+
 ## Hooks
 
 ### useInstanceState
@@ -786,6 +820,104 @@ function MyWorld() {
 :::tip[Omitting yaw]
 When `yaw` is omitted, the player's current orientation is maintained after teleporting. Only specify it when you want the player to face a specific direction.
 :::
+
+---
+
+### useInstance
+
+A hook that provides instance information retrieval and navigation with confirmation. It internally uses `useConfirm` to display a confirmation modal before navigation.
+
+```tsx
+import { useInstance } from '@xrift/world-components'
+
+function MyComponent() {
+  const { info, navigateWithConfirm } = useInstance('target-instance-id')
+
+  if (!info) return null
+
+  return (
+    <mesh onClick={navigateWithConfirm}>
+      {/* Instance name: {info.name} */}
+    </mesh>
+  )
+}
+```
+
+#### Arguments
+
+| Argument | Type | Description |
+|-----|------|-------------|
+| `instanceId` | `string` | ID of the instance to retrieve |
+
+#### Return Value
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `info` | `InstanceInfo \| null` | Instance information (null before fetching) |
+| `navigateWithConfirm` | `() => Promise<void>` | Navigate to instance with confirmation modal |
+
+#### InstanceInfo Type
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `string` | Instance ID |
+| `name` | `string` | Instance name |
+| `description` | `string \| null` | Description |
+| `currentUsers` | `number` | Current number of users |
+| `maxCapacity` | `number` | Maximum capacity |
+| `isPublic` | `boolean` | Whether it is public |
+| `allowGuests` | `boolean` | Whether guests are allowed |
+| `owner` | `{ id, displayName, userIconUrl? }` | Owner information (optional) |
+| `world` | `WorldInfo` | Information about the world it belongs to |
+
+---
+
+### useWorld
+
+A hook that provides world information retrieval.
+
+```tsx
+import { useWorld } from '@xrift/world-components'
+
+function MyComponent() {
+  const { info } = useWorld('target-world-id')
+
+  if (!info) return null
+
+  return (
+    <mesh>
+      {/* World name: {info.name} */}
+    </mesh>
+  )
+}
+```
+
+#### Arguments
+
+| Argument | Type | Description |
+|-----|------|-------------|
+| `worldId` | `string` | ID of the world to retrieve |
+
+#### Return Value
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `info` | `WorldInfo \| null` | World information (null before fetching) |
+
+#### WorldInfo Type
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `string` | World ID |
+| `name` | `string` | World name |
+| `description` | `string \| null` | Description |
+| `thumbnailUrl` | `string \| null` | Thumbnail URL |
+| `isPublic` | `boolean` | Whether it is public |
+| `instanceCount` | `number` | Number of instances |
+| `totalVisitCount` | `number` | Total visit count |
+| `uniqueVisitorCount` | `number` | Unique visitor count |
+| `favoriteCount` | `number` | Favorite count |
+| `owner` | `{ id, displayName, userIconUrl? }` | Owner information (optional) |
 
 ---
 


### PR DESCRIPTION
## Summary
- Portal コンポーネント（他インスタンスへの移動ポータル）のドキュメントを追加
- useInstance フック（インスタンス情報取得・確認付き遷移）のドキュメントを追加
- useWorld フック（ワールド情報取得）のドキュメントを追加
- 日本語・英語の両方を更新

Closes #37

## Test plan
- [ ] `npm run start` でドキュメントサイトを起動し、API リファレンスページに Portal / useInstance / useWorld が正しく表示されることを確認
- [ ] 英語版 (`npm run start -- --locale en`) でも同様に確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)