### PR TITLE
docs: Portal の instanceId がURLから取得できることを説明に追加

### DIFF
--- a/docs/world-components/components/index.md
+++ b/docs/world-components/components/index.md
@@ -428,7 +428,7 @@ import { Portal } from '@xrift/world-components'
 function MyWorld() {
   return (
     <Portal
-      instanceId="target-instance-id"
+      instanceId="ceffb128-23c7-4120-b4e6-19bf6c604c47"
       position={[5, 0, 0]}
       rotation={[0, Math.PI / 2, 0]}
     />
@@ -443,6 +443,10 @@ function MyWorld() {
 | `instanceId` | `string` | - | 移動先のインスタンスID（必須） |
 | `position` | `[number, number, number]` | `[0, 0, 0]` | ポータルの座標 |
 | `rotation` | `[number, number, number]` | `[0, 0, 0]` | ポータルの回転 |
+
+:::tip[インスタンスIDの確認方法]
+インスタンスIDはインスタンスページのURLに含まれる UUID です。例えば `https://app.xrift.net/instance/ceffb128-23c7-4120-b4e6-19bf6c604c47` の場合、`ceffb128-23c7-4120-b4e6-19bf6c604c47` がインスタンスIDです。
+:::
 
 :::note[内部で使用するフック]
 `Portal` は内部で `useInstance` フックを使用してインスタンス情報の取得と遷移を行っています。

--- a/i18n/en/docusaurus-plugin-content-docs/current/world-components/components/index.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/world-components/components/index.md
@@ -428,7 +428,7 @@ import { Portal } from '@xrift/world-components'
 function MyWorld() {
   return (
     <Portal
-      instanceId="target-instance-id"
+      instanceId="ceffb128-23c7-4120-b4e6-19bf6c604c47"
       position={[5, 0, 0]}
       rotation={[0, Math.PI / 2, 0]}
     />
@@ -443,6 +443,10 @@ function MyWorld() {
 | `instanceId` | `string` | - | ID of the destination instance (Required) |
 | `position` | `[number, number, number]` | `[0, 0, 0]` | Position of the portal |
 | `rotation` | `[number, number, number]` | `[0, 0, 0]` | Rotation of the portal |
+
+:::tip[How to find the Instance ID]
+The instance ID is a UUID found in the instance page URL. For example, in `https://app.xrift.net/instance/ceffb128-23c7-4120-b4e6-19bf6c604c47`, the instance ID is `ceffb128-23c7-4120-b4e6-19bf6c604c47`.
+:::
 
 :::note[Internally Used Hook]
 `Portal` internally uses the `useInstance` hook to fetch instance information and handle navigation.


### PR DESCRIPTION
## Summary
- Portal コンポーネントの Props セクションに、インスタンスIDがURLの UUID であることを説明する tip を追加
- コード例の `instanceId` を実際の UUID 形式に変更
- 日本語・英語の両方を更新

## Test plan
- [ ] API リファレンスページで Portal セクションに tip が正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)