### PR TITLE
docs: useConfirm フックのドキュメントを追加

### DIFF
--- a/docs/world-components/components/index.md
+++ b/docs/world-components/components/index.md
@@ -827,6 +827,83 @@ function MyWorld() {
 
 ---
 
+### useConfirm
+
+ユーザーに確認モーダルを表示するフックです。ワールド移動など重要なアクションの前に確認を求めることができます。
+
+```tsx
+import { useConfirm } from '@xrift/world-components';
+
+function MyComponent() {
+  const { requestConfirm } = useConfirm();
+
+  const handleAction = async () => {
+    const ok = await requestConfirm({ message: 'ワールドを移動しますか？' });
+    if (ok) {
+      // 確認された場合の処理
+    }
+  };
+}
+```
+
+#### 戻り値
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `requestConfirm` | `(options: ConfirmOptions) => Promise<boolean>` | 確認モーダルを表示し、結果を返す |
+
+#### ConfirmOptions
+
+| Property | Type | 必須 | Description |
+|----------|------|------|-------------|
+| `message` | `string` | Yes | ユーザーに表示するメッセージ |
+| `title` | `string` | No | ダイアログのタイトル |
+| `confirmLabel` | `string` | No | 確認ボタンのラベル |
+| `cancelLabel` | `string` | No | キャンセルボタンのラベル |
+
+#### 使用例
+
+##### 外部サイトへの遷移前に確認
+
+```tsx
+import { useConfirm, Interactable } from '@xrift/world-components'
+
+function ExternalLink() {
+  const { requestConfirm } = useConfirm()
+
+  const handleClick = async () => {
+    const ok = await requestConfirm({
+      title: '外部サイトへ移動',
+      message: '外部サイトへ移動します。よろしいですか？',
+      confirmLabel: '移動する',
+      cancelLabel: 'キャンセル',
+    })
+    if (ok) {
+      window.open('https://example.com', '_blank')
+    }
+  }
+
+  return (
+    <Interactable id="external-link" onInteract={handleClick}>
+      <mesh>
+        <boxGeometry args={[1, 1, 0.2]} />
+        <meshStandardMaterial color="cyan" />
+      </mesh>
+    </Interactable>
+  )
+}
+```
+
+:::tip[iOS Safari のポップアップブロック回避]
+iPhone 等のモバイルブラウザでは、ユーザー操作を起点としない `window.open` や外部サイトへの遷移がブロックされます。`useConfirm` で確認ダイアログを挟むことで、ユーザー操作起点のイベントチェーンを作り、ブラウザのポップアップブロックを回避できます。
+:::
+
+:::note[Portal コンポーネントとの関係]
+`Portal` コンポーネントは内部で `useInstance` フックを経由して `useConfirm` を使用しています。Portal を使う場合は `useConfirm` を直接呼ぶ必要はありません。
+:::
+
+---
+
 ### useInstance
 
 インスタンス情報の取得と確認付き遷移を提供するフックです。内部で `useConfirm` を使い、遷移前に確認モーダルを表示します。

--- a/i18n/en/docusaurus-plugin-content-docs/current/world-components/components/index.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/world-components/components/index.md
@@ -827,6 +827,83 @@ When `yaw` is omitted, the player's current orientation is maintained after tele
 
 ---
 
+### useConfirm
+
+A hook for displaying a confirmation modal to the user. Use it to ask for confirmation before important actions such as world navigation.
+
+```tsx
+import { useConfirm } from '@xrift/world-components';
+
+function MyComponent() {
+  const { requestConfirm } = useConfirm();
+
+  const handleAction = async () => {
+    const ok = await requestConfirm({ message: 'Move to another world?' });
+    if (ok) {
+      // Proceed with the action
+    }
+  };
+}
+```
+
+#### Returns
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `requestConfirm` | `(options: ConfirmOptions) => Promise<boolean>` | Display a confirmation modal and return the result |
+
+#### ConfirmOptions
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `message` | `string` | Yes | Message displayed to the user |
+| `title` | `string` | No | Dialog title |
+| `confirmLabel` | `string` | No | Label for the confirm button |
+| `cancelLabel` | `string` | No | Label for the cancel button |
+
+#### Usage Example
+
+##### Confirm before navigating to an external site
+
+```tsx
+import { useConfirm, Interactable } from '@xrift/world-components'
+
+function ExternalLink() {
+  const { requestConfirm } = useConfirm()
+
+  const handleClick = async () => {
+    const ok = await requestConfirm({
+      title: 'Navigate to external site',
+      message: 'You are about to leave this world. Continue?',
+      confirmLabel: 'Go',
+      cancelLabel: 'Cancel',
+    })
+    if (ok) {
+      window.open('https://example.com', '_blank')
+    }
+  }
+
+  return (
+    <Interactable id="external-link" onInteract={handleClick}>
+      <mesh>
+        <boxGeometry args={[1, 1, 0.2]} />
+        <meshStandardMaterial color="cyan" />
+      </mesh>
+    </Interactable>
+  )
+}
+```
+
+:::tip[iOS Safari Popup Blocker Workaround]
+On mobile browsers like iPhone, `window.open` and external site navigation are blocked unless triggered by a user gesture. By using `useConfirm` to display a confirmation dialog, you create a user-gesture event chain that allows navigation to proceed without being blocked.
+:::
+
+:::note[Relationship with Portal component]
+The `Portal` component internally uses `useConfirm` via the `useInstance` hook. When using Portal, you don't need to call `useConfirm` directly.
+:::
+
+---
+
 ### useInstance
 
 A hook that provides instance information retrieval and navigation with confirmation. It internally uses `useConfirm` to display a confirmation modal before navigation.


### PR DESCRIPTION
## Summary
- useConfirm フックの API リファレンスを日本語・英語の両方に追加
- useTeleport と useInstance の間に配置

## 含まれる内容
- API（`requestConfirm` の戻り値）
- `ConfirmOptions` パラメータ
- 外部サイト遷移前の確認の使用例
- iOS Safari のポップアップブロック回避の説明
- Portal コンポーネントとの関係の補足

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)