### PR TITLE
docs: Module Federation shared パッケージ一覧ドキュメントを追加

### DIFF
--- a/docs/guides/shared-dependencies.md
+++ b/docs/guides/shared-dependencies.md
@@ -45,18 +45,43 @@ export default defineConfig({
   plugins: [
     federation({
       shared: {
-        react: { singleton: true },
-        'react-dom': { singleton: true },
-        three: { singleton: true },
-        'three/addons/loaders/GLTFLoader.js': { singleton: true },
-        'three/addons/loaders/DRACOLoader.js': { singleton: true },
-        'three/addons/loaders/KTX2Loader.js': { singleton: true },
-        '@react-three/fiber': { singleton: true },
-        '@react-three/rapier': { singleton: true },
-        '@react-three/drei': { singleton: true },
-        '@react-three/uikit': { singleton: true },
-        '@pmndrs/uikit': { singleton: true },
-        '@xrift/world-components': { singleton: true },
+        react: {
+          singleton: true,
+          requiredVersion: '^19.0.0',
+        },
+        'react-dom': {
+          singleton: true,
+          requiredVersion: '^19.0.0',
+        },
+        'react-dom/client': {
+          singleton: true,
+        },
+        'react/jsx-runtime': {
+          singleton: true,
+        },
+        three: {
+          singleton: true,
+          requiredVersion: '^0.176.0',
+        },
+        'three/addons/loaders/DRACOLoader.js': {
+          singleton: true,
+        },
+        '@react-three/fiber': {
+          singleton: true,
+          requiredVersion: '^9.3.0',
+        },
+        '@react-three/rapier': {
+          singleton: true,
+          requiredVersion: '^2.1.0',
+        },
+        '@react-three/drei': {
+          singleton: true,
+          requiredVersion: '^10.7.3',
+        },
+        '@xrift/world-components': {
+          singleton: true,
+          requiredVersion: '^0.1.0',
+        },
       },
     }),
   ],

--- a/docs/guides/shared-dependencies.md
+++ b/docs/guides/shared-dependencies.md
@@ -1,0 +1,64 @@
+---
+sidebar_position: 4
+---
+
+# Shared パッケージ一覧
+
+ワールドの `vite.config.ts` で Module Federation の `shared` に宣言したパッケージは、ホスト（xrift.net）側の shared から解決されます。このページでは、ホスト側で shared として提供されているパッケージの一覧を掲載しています。
+
+## パッケージ一覧
+
+| パッケージ | バージョン要件 | 説明 |
+|-----------|------------|------|
+| `react` | ^19.0.0 | React |
+| `react-dom` | ^19.0.0 | React DOM |
+| `react-dom/client` | - | React DOM client |
+| `react/jsx-runtime` | ^19.0.0 | JSX ランタイム |
+| `three` | ^0.176.0 | Three.js |
+| `three/addons/loaders/GLTFLoader.js` | - | GLTF モデルローダー |
+| `three/addons/loaders/DRACOLoader.js` | - | Draco 圧縮メッシュローダー |
+| `three/addons/loaders/KTX2Loader.js` | - | KTX2 テクスチャローダー |
+| `@react-three/fiber` | ^9.0.0 | React Three Fiber |
+| `@react-three/rapier` | ^2.0.0 | 物理演算 |
+| `@react-three/drei` | ^10.0.0 | Three.js ヘルパー |
+| `@react-three/uikit` | ^1.0.0 | 3D UI |
+| `@pmndrs/uikit` | ^1.0.0 | UIKit コア |
+| `@xrift/world-components` | ^0.1.0 | XRift ワールドコンポーネント |
+
+## three/addons の注意点
+
+`three/addons` バレルファイル全体を shared にすると Lottie 由来の `eval` がバンドルに含まれるため、**サブパス単位**で shared にしています。
+
+ワールド側でも `three/addons/loaders/DRACOLoader.js` のようにサブパスで shared を宣言する必要があります。
+
+:::caution
+`three/addons` をそのまま shared に指定しないでください。サブパス単位で指定する必要があります。
+:::
+
+## ワールド側の設定例
+
+```js
+// vite.config.ts (ワールド側)
+import federation from '@originjs/vite-plugin-federation';
+
+export default defineConfig({
+  plugins: [
+    federation({
+      shared: {
+        react: { singleton: true },
+        'react-dom': { singleton: true },
+        three: { singleton: true },
+        'three/addons/loaders/GLTFLoader.js': { singleton: true },
+        'three/addons/loaders/DRACOLoader.js': { singleton: true },
+        'three/addons/loaders/KTX2Loader.js': { singleton: true },
+        '@react-three/fiber': { singleton: true },
+        '@react-three/rapier': { singleton: true },
+        '@react-three/drei': { singleton: true },
+        '@react-three/uikit': { singleton: true },
+        '@pmndrs/uikit': { singleton: true },
+        '@xrift/world-components': { singleton: true },
+      },
+    }),
+  ],
+});
+```

--- a/i18n/en/docusaurus-plugin-content-docs/current/guides/shared-dependencies.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/guides/shared-dependencies.md
@@ -45,18 +45,43 @@ export default defineConfig({
   plugins: [
     federation({
       shared: {
-        react: { singleton: true },
-        'react-dom': { singleton: true },
-        three: { singleton: true },
-        'three/addons/loaders/GLTFLoader.js': { singleton: true },
-        'three/addons/loaders/DRACOLoader.js': { singleton: true },
-        'three/addons/loaders/KTX2Loader.js': { singleton: true },
-        '@react-three/fiber': { singleton: true },
-        '@react-three/rapier': { singleton: true },
-        '@react-three/drei': { singleton: true },
-        '@react-three/uikit': { singleton: true },
-        '@pmndrs/uikit': { singleton: true },
-        '@xrift/world-components': { singleton: true },
+        react: {
+          singleton: true,
+          requiredVersion: '^19.0.0',
+        },
+        'react-dom': {
+          singleton: true,
+          requiredVersion: '^19.0.0',
+        },
+        'react-dom/client': {
+          singleton: true,
+        },
+        'react/jsx-runtime': {
+          singleton: true,
+        },
+        three: {
+          singleton: true,
+          requiredVersion: '^0.176.0',
+        },
+        'three/addons/loaders/DRACOLoader.js': {
+          singleton: true,
+        },
+        '@react-three/fiber': {
+          singleton: true,
+          requiredVersion: '^9.3.0',
+        },
+        '@react-three/rapier': {
+          singleton: true,
+          requiredVersion: '^2.1.0',
+        },
+        '@react-three/drei': {
+          singleton: true,
+          requiredVersion: '^10.7.3',
+        },
+        '@xrift/world-components': {
+          singleton: true,
+          requiredVersion: '^0.1.0',
+        },
       },
     }),
   ],

--- a/i18n/en/docusaurus-plugin-content-docs/current/guides/shared-dependencies.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/guides/shared-dependencies.md
@@ -1,0 +1,64 @@
+---
+sidebar_position: 4
+---
+
+# Shared Packages
+
+Packages declared in the `shared` section of Module Federation in your world's `vite.config.ts` are resolved from the host (xrift.net) side. This page lists all packages provided as shared by the host.
+
+## Package List
+
+| Package | Version Requirement | Description |
+|---------|-------------------|-------------|
+| `react` | ^19.0.0 | React |
+| `react-dom` | ^19.0.0 | React DOM |
+| `react-dom/client` | - | React DOM client |
+| `react/jsx-runtime` | ^19.0.0 | JSX runtime |
+| `three` | ^0.176.0 | Three.js |
+| `three/addons/loaders/GLTFLoader.js` | - | GLTF model loader |
+| `three/addons/loaders/DRACOLoader.js` | - | Draco compressed mesh loader |
+| `three/addons/loaders/KTX2Loader.js` | - | KTX2 texture loader |
+| `@react-three/fiber` | ^9.0.0 | React Three Fiber |
+| `@react-three/rapier` | ^2.0.0 | Physics engine |
+| `@react-three/drei` | ^10.0.0 | Three.js helpers |
+| `@react-three/uikit` | ^1.0.0 | 3D UI |
+| `@pmndrs/uikit` | ^1.0.0 | UIKit core |
+| `@xrift/world-components` | ^0.1.0 | XRift world components |
+
+## Notes on three/addons
+
+Sharing the entire `three/addons` barrel file would include `eval` from Lottie in the bundle, so packages are shared at the **subpath level**.
+
+You also need to declare shared packages using subpaths like `three/addons/loaders/DRACOLoader.js` on the world side.
+
+:::caution
+Do not specify `three/addons` directly as shared. You must specify it at the subpath level.
+:::
+
+## World-side Configuration Example
+
+```js
+// vite.config.ts (world side)
+import federation from '@originjs/vite-plugin-federation';
+
+export default defineConfig({
+  plugins: [
+    federation({
+      shared: {
+        react: { singleton: true },
+        'react-dom': { singleton: true },
+        three: { singleton: true },
+        'three/addons/loaders/GLTFLoader.js': { singleton: true },
+        'three/addons/loaders/DRACOLoader.js': { singleton: true },
+        'three/addons/loaders/KTX2Loader.js': { singleton: true },
+        '@react-three/fiber': { singleton: true },
+        '@react-three/rapier': { singleton: true },
+        '@react-three/drei': { singleton: true },
+        '@react-three/uikit': { singleton: true },
+        '@pmndrs/uikit': { singleton: true },
+        '@xrift/world-components': { singleton: true },
+      },
+    }),
+  ],
+});
+```

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -18,6 +18,7 @@ const sidebars: SidebarsConfig = {
         'guides/create-first-world',
         'guides/configuration',
         'guides/triplex',
+        'guides/shared-dependencies',
         'world-components/components/index',
       ],
     },


### PR DESCRIPTION
## Summary
- ワールド開発者がホスト（xrift.net）と shared で共有されるパッケージを把握できるよう、`docs/guides/shared-dependencies.md` を追加
- `three/addons` がサブパス単位で shared になっている注意点を記載
- ワールド側の `vite.config.ts` 設定例を掲載
- 日本語・英語の両言語対応

Closes #52

## Test plan
- [ ] `npm start` でローカルプレビューし、新規ページが正しく表示されることを確認
- [ ] サイドバーの「ワールド開発」カテゴリに「Shared パッケージ一覧」が表示されることを確認
- [ ] 英語版 (`npm start -- --locale en`) でも同様に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)