### PR TITLE
docs: outputBufferType の設定ドキュメントを追加

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -25,6 +25,7 @@ sidebar_position: 2
       "near": 0.1,
       "far": 1000
     },
+    "outputBufferType": "UnsignedByteType",
     "permissions": {
       "allowedDomains": ["api.example.com"],
       "allowedCodeRules": ["no-storage-access"]
@@ -45,6 +46,7 @@ sidebar_position: 2
 | `ignore` | string[] | アップロードから除外するファイルの glob パターン |
 | `physics` | object | ワールドの物理設定 |
 | `camera` | object | ワールドのカメラクリッピング設定 |
+| `outputBufferType` | string | WebGLRenderer の出力バッファタイプ |
 | `permissions` | object | ワールドが必要とする権限設定 |
 
 ## 各項目の詳細
@@ -221,6 +223,24 @@ sidebar_position: 2
     "camera": {
       "near": 0.01
     }
+  }
+}
+```
+
+### outputBufferType
+
+WebGLRenderer の出力バッファタイプを指定します。ポストプロセッシングや HDR レンダリングの精度に影響します。
+
+| 値 | 説明 |
+|-----|------|
+| `UnsignedByteType` | 8bit 整数（デフォルト。通常のレンダリングに適する） |
+| `HalfFloatType` | 16bit 浮動小数点（HDR やポストプロセッシングに適する） |
+| `FloatType` | 32bit 浮動小数点（最高精度。GPU 負荷が高い） |
+
+```json
+{
+  "world": {
+    "outputBufferType": "HalfFloatType"
   }
 }
 ```

--- a/i18n/en/docusaurus-plugin-content-docs/current/guides/configuration.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/guides/configuration.md
@@ -21,6 +21,7 @@ Configure your world settings in `xrift.json` at the project root.
       "**/Thumbs.db",
       "**/*.map"
     ],
+    "outputBufferType": "UnsignedByteType",
     "permissions": {
       "allowedDomains": ["api.example.com"],
       "allowedCodeRules": ["no-storage-access"]
@@ -40,6 +41,8 @@ Configure your world settings in `xrift.json` at the project root.
 | `buildCommand` | string | Build command to execute before upload |
 | `ignore` | string[] | Glob patterns of files to exclude from upload |
 | `physics` | object | World physics settings |
+| `camera` | object | World camera clipping settings |
+| `outputBufferType` | string | WebGLRenderer output buffer type |
 | `permissions` | object | Permissions required by the world |
 
 ## Details of Each Item
@@ -170,6 +173,24 @@ You can customize the physics behavior of the world.
     "physics": {
       "gravity": 24.79
     }
+  }
+}
+```
+
+### outputBufferType
+
+Specifies the output buffer type for WebGLRenderer. This affects the precision of post-processing and HDR rendering.
+
+| Value | Description |
+|-------|-------------|
+| `UnsignedByteType` | 8-bit integer (default, suitable for standard rendering) |
+| `HalfFloatType` | 16-bit float (suitable for HDR and post-processing) |
+| `FloatType` | 32-bit float (highest precision, higher GPU cost) |
+
+```json
+{
+  "world": {
+    "outputBufferType": "HalfFloatType"
   }
 }
 ```


### PR DESCRIPTION
## Summary
- xrift.json の world 設定に `outputBufferType` のドキュメントを追加
- `UnsignedByteType` / `HalfFloatType` / `FloatType` の各値の説明と設定例を記載
- 日本語・英語の両方を更新

## Test plan
- [ ] ローカルで Docusaurus のビルド/プレビューが正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)