### PR TITLE
docs: add @xrift/sdk documentation

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -35,6 +35,13 @@ XRift では、独自の 3D ワールドを作成できます。React Three Fibe
 - [CLI ドキュメント](/cli/overview)
 - [GitHub](https://github.com/WebXR-JP/xrift-cli)
 
+### @xrift/sdk
+
+XRift プラットフォーム向けのユニバーサル SDK。Node.js とブラウザの両環境でワールド・アイテムの API 操作とファイルアップロードを提供します。
+
+- [SDK ドキュメント](/sdk/overview)
+- [GitHub](https://github.com/WebXR-JP/xrift-sdk)
+
 ### xrift-world-components
 
 WebXR ワールドを構築するための React コンポーネントライブラリ。

--- a/docs/sdk/api-reference.md
+++ b/docs/sdk/api-reference.md
@@ -1,0 +1,301 @@
+---
+sidebar_position: 2
+---
+
+# API リファレンス
+
+`@xrift/sdk` の全 API リファレンスです。
+
+## XriftClient
+
+SDK のエントリーポイント。ワールド API とアイテム API をまとめて提供します。
+
+```typescript
+import { XriftClient } from '@xrift/sdk';
+
+const client = new XriftClient({
+  token: 'your-api-token',
+  baseUrl: 'https://api.xrift.net', // オプション
+  timeout: 30000,                    // オプション (ms)
+});
+```
+
+### コンストラクタ
+
+| パラメータ | 型 | 必須 | デフォルト | 説明 |
+|-----------|-----|------|-----------|------|
+| `token` | `string` | はい | - | API 認証トークン |
+| `baseUrl` | `string` | いいえ | `https://api.xrift.net` | API ベース URL |
+| `timeout` | `number` | いいえ | `30000` | リクエストタイムアウト (ms) |
+
+### プロパティ
+
+| プロパティ | 型 | 説明 |
+|-----------|-----|------|
+| `worlds` | `WorldsApi` | ワールド操作 API |
+| `items` | `ItemsApi` | アイテム操作 API |
+
+---
+
+## WorldsApi
+
+ワールドの作成・アップロードを行う API です。`client.worlds` からアクセスします。
+
+### `upload(files, options)`
+
+ワールドアップロードの統合メソッド。作成→ハッシュ計算→URL 取得→アップロード→完了通知を一括で実行します。
+
+```typescript
+const result = await client.worlds.upload(files, options);
+```
+
+**パラメータ:**
+
+| 名前 | 型 | 説明 |
+|------|-----|------|
+| `files` | `UploadFile[]` | アップロードするファイルの配列 |
+| `options` | `WorldUploadOptions` | アップロードオプション |
+
+**WorldUploadOptions:**
+
+| フィールド | 型 | 必須 | 説明 |
+|-----------|-----|------|------|
+| `worldId` | `string` | いいえ | 既存ワールドの ID（省略時は新規作成） |
+| `name` | `string` | はい | ワールド名 |
+| `description` | `string` | いいえ | 説明 |
+| `thumbnailPath` | `string` | いいえ | サムネイルのパス |
+| `physics` | `PhysicsConfig` | いいえ | 物理設定 |
+| `camera` | `CameraConfig` | いいえ | カメラ設定 |
+| `permissions` | `WorldPermissions` | いいえ | 権限設定 |
+| `outputBufferType` | `OutputBufferType` | いいえ | 出力バッファ型 |
+| `onProgress` | `(progress: UploadProgress) => void` | いいえ | 進捗コールバック |
+
+**戻り値: `WorldUploadResult`**
+
+| フィールド | 型 | 説明 |
+|-----------|-----|------|
+| `worldId` | `string` | ワールド ID |
+| `versionId` | `string` | バージョン ID |
+| `versionNumber` | `number` | バージョン番号 |
+| `contentHash` | `string` | コンテンツハッシュ |
+| `files` | `UploadFile[]` | アップロードしたファイル |
+
+### `create()`
+
+新しいワールドを作成します。
+
+```typescript
+const world = await client.worlds.create();
+console.log(world.id); // ワールド ID
+```
+
+**戻り値: `CreateWorldResponse`**
+
+| フィールド | 型 | 説明 |
+|-----------|-----|------|
+| `id` | `string` | ワールド ID |
+| `ownerId` | `string` | オーナー ID |
+| `createdAt` | `string` | 作成日時 |
+| `updatedAt` | `string` | 更新日時 |
+
+### `getUploadUrls(worldId, request)`
+
+署名付きアップロード URL を取得します。
+
+```typescript
+const urls = await client.worlds.getUploadUrls(worldId, {
+  name: 'My World',
+  contentHash: 'abc123def456',
+  fileSize: 1024,
+  files: [{ path: 'scene.glb', contentType: 'model/gltf-binary' }],
+});
+```
+
+### `complete(worldId, versionId)`
+
+アップロードの完了を通知します。
+
+```typescript
+await client.worlds.complete(worldId, versionId);
+```
+
+---
+
+## ItemsApi
+
+アイテムの作成・アップロードを行う API です。`client.items` からアクセスします。
+
+### `upload(files, options)`
+
+アイテムアップロードの統合メソッド。
+
+```typescript
+const result = await client.items.upload(files, options);
+```
+
+**ItemUploadOptions:**
+
+| フィールド | 型 | 必須 | 説明 |
+|-----------|-----|------|------|
+| `itemId` | `string` | いいえ | 既存アイテムの ID（省略時は新規作成） |
+| `name` | `string` | はい | アイテム名 |
+| `description` | `string` | いいえ | 説明 |
+| `thumbnailPath` | `string` | いいえ | サムネイルのパス |
+| `permissions` | `ItemPermissions` | いいえ | 権限設定 |
+| `onProgress` | `(progress: UploadProgress) => void` | いいえ | 進捗コールバック |
+
+**戻り値: `ItemUploadResult`**
+
+| フィールド | 型 | 説明 |
+|-----------|-----|------|
+| `itemId` | `string` | アイテム ID |
+| `versionId` | `string` | バージョン ID |
+| `versionNumber` | `number` | バージョン番号 |
+| `contentHash` | `string` | コンテンツハッシュ |
+| `files` | `UploadFile[]` | アップロードしたファイル |
+
+### `create()`
+
+新しいアイテムを作成します。
+
+```typescript
+const item = await client.items.create();
+console.log(item.id);
+```
+
+### `getUploadUrls(itemId, request)`
+
+署名付きアップロード URL を取得します。
+
+### `complete(itemId, versionId)`
+
+アップロードの完了を通知します。
+
+---
+
+## エラークラス
+
+SDK は以下のエラー階層を提供します。
+
+```
+XriftSdkError (基底クラス)
+├── XriftApiError (API エラー)
+│   └── XriftAuthError (認証エラー: 401)
+└── XriftNetworkError (ネットワークエラー)
+```
+
+### XriftApiError
+
+API がエラーレスポンスを返した場合にスローされます。
+
+| プロパティ | 型 | 説明 |
+|-----------|-----|------|
+| `message` | `string` | エラーメッセージ |
+| `statusCode` | `number` | HTTP ステータスコード |
+| `responseBody` | `unknown` | レスポンスボディ |
+
+### XriftAuthError
+
+認証に失敗した場合（HTTP 401）にスローされます。`XriftApiError` を継承しています。
+
+### XriftNetworkError
+
+ネットワーク接続エラーの場合にスローされます。
+
+| プロパティ | 型 | 説明 |
+|-----------|-----|------|
+| `message` | `string` | エラーメッセージ |
+| `cause` | `Error` | 原因となったエラー |
+
+### エラーハンドリング例
+
+```typescript
+import {
+  XriftAuthError,
+  XriftApiError,
+  XriftNetworkError,
+} from '@xrift/sdk';
+
+try {
+  await client.worlds.upload(files, options);
+} catch (error) {
+  if (error instanceof XriftAuthError) {
+    console.error('認証エラー: トークンを確認してください');
+  } else if (error instanceof XriftApiError) {
+    console.error(`API エラー (${error.statusCode}): ${error.message}`);
+  } else if (error instanceof XriftNetworkError) {
+    console.error('ネットワークエラー:', error.message);
+  }
+}
+```
+
+---
+
+## ユーティリティ
+
+### `calculateContentHash(files, configValues?)`
+
+ファイルと設定値から SHA-256 ベースのコンテンツハッシュ（先頭 12 文字）を計算します。Node.js では `node:crypto`、ブラウザでは Web Crypto API を自動的に使い分けます。
+
+```typescript
+import { calculateContentHash } from '@xrift/sdk';
+
+const hash = await calculateContentHash(
+  [{ remotePath: 'scene.glb', data: fileData }],
+  { physics: { gravity: -9.8 } },
+);
+```
+
+### `getMimeType(filePath)`
+
+ファイルパスの拡張子から MIME タイプを判定します。
+
+```typescript
+import { getMimeType } from '@xrift/sdk';
+
+getMimeType('scene.glb');    // 'model/gltf-binary'
+getMimeType('texture.png');  // 'image/png'
+getMimeType('unknown.xyz');  // 'application/octet-stream'
+```
+
+対応する拡張子: `.glb`, `.gltf`, `.png`, `.jpg`, `.jpeg`, `.webp`, `.json`, `.js`, `.mjs`, `.html`, `.css`, `.txt`, `.bin`, `.wasm`, `.svg`, `.mp3`, `.ogg`, `.wav`, `.mp4`, `.webm`, `.ktx2`, `.basis`, `.hdr`, `.exr`
+
+---
+
+## 型定義
+
+### 共通型
+
+| 型名 | 説明 |
+|------|------|
+| `FileData` | `ArrayBuffer \| Uint8Array` — ファイルのバイナリデータ |
+| `UploadFile` | アップロードファイル（remotePath, size, contentType, data） |
+| `UploadProgress` | 進捗情報（completed, total, currentFile） |
+| `PhysicsConfig` | 物理設定（gravity, allowInfiniteJump） |
+| `CameraConfig` | カメラ設定（near, far） |
+| `OutputBufferType` | `'UnsignedByteType' \| 'HalfFloatType' \| 'FloatType'` |
+| `SignedUrlResponse` | 署名付き URL レスポンス |
+
+### ワールド型
+
+| 型名 | 説明 |
+|------|------|
+| `WorldPermissions` | 権限設定（allowedDomains, allowedCodeRules） |
+| `CreateWorldResponse` | ワールド作成レスポンス |
+| `WorldUploadUrlsRequest` | アップロード URL リクエスト |
+| `WorldUploadUrlsResponse` | アップロード URL レスポンス |
+| `CompleteWorldUploadResponse` | アップロード完了レスポンス |
+| `WorldUploadOptions` | アップロードオプション |
+| `WorldUploadResult` | アップロード結果 |
+
+### アイテム型
+
+| 型名 | 説明 |
+|------|------|
+| `ItemPermissions` | 権限設定（allowedDomains, allowedCodeRules） |
+| `CreateItemResponse` | アイテム作成レスポンス |
+| `ItemUploadUrlsRequest` | アップロード URL リクエスト |
+| `ItemUploadUrlsResponse` | アップロード URL レスポンス |
+| `CompleteItemUploadResponse` | アップロード完了レスポンス |
+| `ItemUploadOptions` | アップロードオプション |
+| `ItemUploadResult` | アップロード結果 |

--- a/docs/sdk/overview.md
+++ b/docs/sdk/overview.md
@@ -1,0 +1,130 @@
+---
+sidebar_position: 1
+---
+
+# SDK 概要
+
+`@xrift/sdk` は、XRift プラットフォーム向けのユニバーサル SDK です。ワールドやアイテムの API 操作とファイルアップロードを、Node.js とブラウザの両環境で提供します。
+
+## 特徴
+
+- **ユニバーサル**: Node.js とブラウザの両方で動作
+- **外部依存ゼロ**: fetch API ベースで追加パッケージ不要
+- **TypeScript**: 完全な型定義付き
+- **ESM + CJS**: デュアルビルド対応
+- **統合アップロード**: ハッシュ計算・署名付き URL 取得・アップロード・完了通知を一括処理
+
+## インストール
+
+```bash
+npm install @xrift/sdk
+```
+
+## 基本的な使い方
+
+### クライアントの初期化
+
+```typescript
+import { XriftClient } from '@xrift/sdk';
+
+const client = new XriftClient({
+  token: 'your-api-token',
+});
+```
+
+### ワールドのアップロード
+
+```typescript
+import { readFile } from 'node:fs/promises';
+import { XriftClient, getMimeType } from '@xrift/sdk';
+
+const client = new XriftClient({ token: 'your-api-token' });
+
+// ファイルを読み込み
+const data = new Uint8Array(await readFile('scene.glb'));
+
+const result = await client.worlds.upload(
+  [
+    {
+      remotePath: 'scene.glb',
+      data,
+      size: data.byteLength,
+      contentType: getMimeType('scene.glb'),
+    },
+  ],
+  {
+    name: 'My World',
+    description: 'A sample world',
+  },
+);
+
+console.log(`World uploaded: ${result.worldId}`);
+```
+
+### アイテムのアップロード
+
+```typescript
+const result = await client.items.upload(
+  [
+    {
+      remotePath: 'model.glb',
+      data,
+      size: data.byteLength,
+      contentType: getMimeType('model.glb'),
+    },
+  ],
+  {
+    name: 'My Item',
+  },
+);
+
+console.log(`Item uploaded: ${result.itemId}`);
+```
+
+### ブラウザでの使用
+
+```typescript
+// File API からデータを取得
+const fileInput = document.querySelector<HTMLInputElement>('#file');
+const file = fileInput.files[0];
+const data = new Uint8Array(await file.arrayBuffer());
+
+const result = await client.worlds.upload(
+  [
+    {
+      remotePath: file.name,
+      data,
+      size: data.byteLength,
+      contentType: file.type || getMimeType(file.name),
+    },
+  ],
+  {
+    name: 'Browser Upload World',
+  },
+);
+```
+
+### 進捗の追跡
+
+```typescript
+const result = await client.worlds.upload(files, {
+  name: 'My World',
+  onProgress: (progress) => {
+    console.log(`${progress.completed}/${progress.total}: ${progress.currentFile}`);
+  },
+});
+```
+
+## CLI との違い
+
+| | xrift-cli | @xrift/sdk |
+|---|---|---|
+| 用途 | ローカル開発・デプロイ | アプリケーション組み込み |
+| 入力 | ローカルファイルパス | バイナリデータ (ArrayBuffer / Uint8Array) |
+| 環境 | Node.js のみ | Node.js + ブラウザ |
+| 認証 | `xrift login` で取得 | トークンを直接指定 |
+
+## 次のステップ
+
+- [API リファレンス](/sdk/api-reference) - 全 API の詳細仕様
+- [Public API v1](/public-api/v1) - REST API 仕様

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -129,6 +129,10 @@ const config: Config = {
               label: 'xrift-world-components',
               href: 'https://github.com/WebXR-JP/xrift-world-components',
             },
+            {
+              label: 'xrift-sdk',
+              href: 'https://github.com/WebXR-JP/xrift-sdk',
+            },
           ],
         },
         {

--- a/i18n/en/docusaurus-plugin-content-docs/current/intro.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/intro.md
@@ -35,6 +35,13 @@ A command-line tool. It handles project creation, uploading to the XRift platfor
 - [CLI Documentation](/cli/overview)
 - [GitHub](https://github.com/WebXR-JP/xrift-cli)
 
+### @xrift/sdk
+
+A universal SDK for the XRift platform. Provides API operations and file uploads for worlds and items in both Node.js and browser environments.
+
+- [SDK Documentation](/sdk/overview)
+- [GitHub](https://github.com/WebXR-JP/xrift-sdk)
+
 ### xrift-world-components
 
 A React component library for building WebXR worlds.

--- a/i18n/en/docusaurus-plugin-content-docs/current/sdk/api-reference.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/sdk/api-reference.md
@@ -1,0 +1,301 @@
+---
+sidebar_position: 2
+---
+
+# API Reference
+
+Complete API reference for `@xrift/sdk`.
+
+## XriftClient
+
+The entry point of the SDK. Provides access to the Worlds API and Items API.
+
+```typescript
+import { XriftClient } from '@xrift/sdk';
+
+const client = new XriftClient({
+  token: 'your-api-token',
+  baseUrl: 'https://api.xrift.net', // optional
+  timeout: 30000,                    // optional (ms)
+});
+```
+
+### Constructor
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `token` | `string` | Yes | - | API authentication token |
+| `baseUrl` | `string` | No | `https://api.xrift.net` | API base URL |
+| `timeout` | `number` | No | `30000` | Request timeout (ms) |
+
+### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `worlds` | `WorldsApi` | Worlds API |
+| `items` | `ItemsApi` | Items API |
+
+---
+
+## WorldsApi
+
+API for creating and uploading worlds. Access via `client.worlds`.
+
+### `upload(files, options)`
+
+Integrated upload method. Executes creation, hash calculation, URL retrieval, upload, and completion notification in one call.
+
+```typescript
+const result = await client.worlds.upload(files, options);
+```
+
+**Parameters:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `files` | `UploadFile[]` | Array of files to upload |
+| `options` | `WorldUploadOptions` | Upload options |
+
+**WorldUploadOptions:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `worldId` | `string` | No | Existing world ID (creates new if omitted) |
+| `name` | `string` | Yes | World name |
+| `description` | `string` | No | Description |
+| `thumbnailPath` | `string` | No | Thumbnail path |
+| `physics` | `PhysicsConfig` | No | Physics settings |
+| `camera` | `CameraConfig` | No | Camera settings |
+| `permissions` | `WorldPermissions` | No | Permission settings |
+| `outputBufferType` | `OutputBufferType` | No | Output buffer type |
+| `onProgress` | `(progress: UploadProgress) => void` | No | Progress callback |
+
+**Returns: `WorldUploadResult`**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `worldId` | `string` | World ID |
+| `versionId` | `string` | Version ID |
+| `versionNumber` | `number` | Version number |
+| `contentHash` | `string` | Content hash |
+| `files` | `UploadFile[]` | Uploaded files |
+
+### `create()`
+
+Creates a new world.
+
+```typescript
+const world = await client.worlds.create();
+console.log(world.id); // World ID
+```
+
+**Returns: `CreateWorldResponse`**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `string` | World ID |
+| `ownerId` | `string` | Owner ID |
+| `createdAt` | `string` | Creation date |
+| `updatedAt` | `string` | Last updated date |
+
+### `getUploadUrls(worldId, request)`
+
+Retrieves signed upload URLs.
+
+```typescript
+const urls = await client.worlds.getUploadUrls(worldId, {
+  name: 'My World',
+  contentHash: 'abc123def456',
+  fileSize: 1024,
+  files: [{ path: 'scene.glb', contentType: 'model/gltf-binary' }],
+});
+```
+
+### `complete(worldId, versionId)`
+
+Notifies upload completion.
+
+```typescript
+await client.worlds.complete(worldId, versionId);
+```
+
+---
+
+## ItemsApi
+
+API for creating and uploading items. Access via `client.items`.
+
+### `upload(files, options)`
+
+Integrated upload method for items.
+
+```typescript
+const result = await client.items.upload(files, options);
+```
+
+**ItemUploadOptions:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `itemId` | `string` | No | Existing item ID (creates new if omitted) |
+| `name` | `string` | Yes | Item name |
+| `description` | `string` | No | Description |
+| `thumbnailPath` | `string` | No | Thumbnail path |
+| `permissions` | `ItemPermissions` | No | Permission settings |
+| `onProgress` | `(progress: UploadProgress) => void` | No | Progress callback |
+
+**Returns: `ItemUploadResult`**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `itemId` | `string` | Item ID |
+| `versionId` | `string` | Version ID |
+| `versionNumber` | `number` | Version number |
+| `contentHash` | `string` | Content hash |
+| `files` | `UploadFile[]` | Uploaded files |
+
+### `create()`
+
+Creates a new item.
+
+```typescript
+const item = await client.items.create();
+console.log(item.id);
+```
+
+### `getUploadUrls(itemId, request)`
+
+Retrieves signed upload URLs.
+
+### `complete(itemId, versionId)`
+
+Notifies upload completion.
+
+---
+
+## Error Classes
+
+The SDK provides the following error hierarchy.
+
+```
+XriftSdkError (base class)
+├── XriftApiError (API errors)
+│   └── XriftAuthError (authentication error: 401)
+└── XriftNetworkError (network errors)
+```
+
+### XriftApiError
+
+Thrown when the API returns an error response.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `message` | `string` | Error message |
+| `statusCode` | `number` | HTTP status code |
+| `responseBody` | `unknown` | Response body |
+
+### XriftAuthError
+
+Thrown on authentication failure (HTTP 401). Extends `XriftApiError`.
+
+### XriftNetworkError
+
+Thrown on network connection errors.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `message` | `string` | Error message |
+| `cause` | `Error` | Underlying error |
+
+### Error Handling Example
+
+```typescript
+import {
+  XriftAuthError,
+  XriftApiError,
+  XriftNetworkError,
+} from '@xrift/sdk';
+
+try {
+  await client.worlds.upload(files, options);
+} catch (error) {
+  if (error instanceof XriftAuthError) {
+    console.error('Auth error: please check your token');
+  } else if (error instanceof XriftApiError) {
+    console.error(`API error (${error.statusCode}): ${error.message}`);
+  } else if (error instanceof XriftNetworkError) {
+    console.error('Network error:', error.message);
+  }
+}
+```
+
+---
+
+## Utilities
+
+### `calculateContentHash(files, configValues?)`
+
+Calculates a SHA-256 based content hash (first 12 characters) from files and configuration values. Automatically uses `node:crypto` in Node.js and Web Crypto API in browsers.
+
+```typescript
+import { calculateContentHash } from '@xrift/sdk';
+
+const hash = await calculateContentHash(
+  [{ remotePath: 'scene.glb', data: fileData }],
+  { physics: { gravity: -9.8 } },
+);
+```
+
+### `getMimeType(filePath)`
+
+Determines MIME type from a file path extension.
+
+```typescript
+import { getMimeType } from '@xrift/sdk';
+
+getMimeType('scene.glb');    // 'model/gltf-binary'
+getMimeType('texture.png');  // 'image/png'
+getMimeType('unknown.xyz');  // 'application/octet-stream'
+```
+
+Supported extensions: `.glb`, `.gltf`, `.png`, `.jpg`, `.jpeg`, `.webp`, `.json`, `.js`, `.mjs`, `.html`, `.css`, `.txt`, `.bin`, `.wasm`, `.svg`, `.mp3`, `.ogg`, `.wav`, `.mp4`, `.webm`, `.ktx2`, `.basis`, `.hdr`, `.exr`
+
+---
+
+## Type Definitions
+
+### Common Types
+
+| Type | Description |
+|------|-------------|
+| `FileData` | `ArrayBuffer \| Uint8Array` — Binary file data |
+| `UploadFile` | Upload file (remotePath, size, contentType, data) |
+| `UploadProgress` | Progress info (completed, total, currentFile) |
+| `PhysicsConfig` | Physics settings (gravity, allowInfiniteJump) |
+| `CameraConfig` | Camera settings (near, far) |
+| `OutputBufferType` | `'UnsignedByteType' \| 'HalfFloatType' \| 'FloatType'` |
+| `SignedUrlResponse` | Signed URL response |
+
+### World Types
+
+| Type | Description |
+|------|-------------|
+| `WorldPermissions` | Permission settings (allowedDomains, allowedCodeRules) |
+| `CreateWorldResponse` | World creation response |
+| `WorldUploadUrlsRequest` | Upload URL request |
+| `WorldUploadUrlsResponse` | Upload URL response |
+| `CompleteWorldUploadResponse` | Upload completion response |
+| `WorldUploadOptions` | Upload options |
+| `WorldUploadResult` | Upload result |
+
+### Item Types
+
+| Type | Description |
+|------|-------------|
+| `ItemPermissions` | Permission settings (allowedDomains, allowedCodeRules) |
+| `CreateItemResponse` | Item creation response |
+| `ItemUploadUrlsRequest` | Upload URL request |
+| `ItemUploadUrlsResponse` | Upload URL response |
+| `CompleteItemUploadResponse` | Upload completion response |
+| `ItemUploadOptions` | Upload options |
+| `ItemUploadResult` | Upload result |

--- a/i18n/en/docusaurus-plugin-content-docs/current/sdk/overview.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/sdk/overview.md
@@ -1,0 +1,130 @@
+---
+sidebar_position: 1
+---
+
+# SDK Overview
+
+`@xrift/sdk` is a universal SDK for the XRift platform. It provides API operations and file uploads for worlds and items, working in both Node.js and browser environments.
+
+## Features
+
+- **Universal**: Works in both Node.js and browser
+- **Zero dependencies**: Based on fetch API, no additional packages needed
+- **TypeScript**: Full type definitions included
+- **ESM + CJS**: Dual build support
+- **Integrated upload**: Hash calculation, signed URL retrieval, upload, and completion notification in one call
+
+## Installation
+
+```bash
+npm install @xrift/sdk
+```
+
+## Basic Usage
+
+### Initializing the Client
+
+```typescript
+import { XriftClient } from '@xrift/sdk';
+
+const client = new XriftClient({
+  token: 'your-api-token',
+});
+```
+
+### Uploading a World
+
+```typescript
+import { readFile } from 'node:fs/promises';
+import { XriftClient, getMimeType } from '@xrift/sdk';
+
+const client = new XriftClient({ token: 'your-api-token' });
+
+// Read the file
+const data = new Uint8Array(await readFile('scene.glb'));
+
+const result = await client.worlds.upload(
+  [
+    {
+      remotePath: 'scene.glb',
+      data,
+      size: data.byteLength,
+      contentType: getMimeType('scene.glb'),
+    },
+  ],
+  {
+    name: 'My World',
+    description: 'A sample world',
+  },
+);
+
+console.log(`World uploaded: ${result.worldId}`);
+```
+
+### Uploading an Item
+
+```typescript
+const result = await client.items.upload(
+  [
+    {
+      remotePath: 'model.glb',
+      data,
+      size: data.byteLength,
+      contentType: getMimeType('model.glb'),
+    },
+  ],
+  {
+    name: 'My Item',
+  },
+);
+
+console.log(`Item uploaded: ${result.itemId}`);
+```
+
+### Browser Usage
+
+```typescript
+// Get data from File API
+const fileInput = document.querySelector<HTMLInputElement>('#file');
+const file = fileInput.files[0];
+const data = new Uint8Array(await file.arrayBuffer());
+
+const result = await client.worlds.upload(
+  [
+    {
+      remotePath: file.name,
+      data,
+      size: data.byteLength,
+      contentType: file.type || getMimeType(file.name),
+    },
+  ],
+  {
+    name: 'Browser Upload World',
+  },
+);
+```
+
+### Tracking Progress
+
+```typescript
+const result = await client.worlds.upload(files, {
+  name: 'My World',
+  onProgress: (progress) => {
+    console.log(`${progress.completed}/${progress.total}: ${progress.currentFile}`);
+  },
+});
+```
+
+## Differences from CLI
+
+| | xrift-cli | @xrift/sdk |
+|---|---|---|
+| Use case | Local development & deployment | Application integration |
+| Input | Local file paths | Binary data (ArrayBuffer / Uint8Array) |
+| Environment | Node.js only | Node.js + Browser |
+| Authentication | Obtained via `xrift login` | Token specified directly |
+
+## Next Steps
+
+- [API Reference](/sdk/api-reference) - Full API specification
+- [Public API v1](/public-api/v1) - REST API specification

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -37,6 +37,14 @@ const sidebars: SidebarsConfig = {
         'cli/commands',
       ],
     },
+    {
+      type: 'category',
+      label: 'SDK (@xrift/sdk)',
+      items: [
+        'sdk/overview',
+        'sdk/api-reference',
+      ],
+    },
     'public-api/v1',
   ],
 };


### PR DESCRIPTION
## Summary
- SDK 概要ページ（`docs/sdk/overview.md`）と API リファレンスページ（`docs/sdk/api-reference.md`）を日英両方で追加
- サイドバーに「SDK (@xrift/sdk)」カテゴリを追加
- intro.md のツールセクションに `@xrift/sdk` を追記
- フッターの Repositories に xrift-sdk リンクを追加

## Test plan
- [x] `npm run build` でビルドエラーなし（ja / en 両方成功）
- [ ] デプロイ後にページが正しく表示されることを確認
- [ ] サイドバーの SDK カテゴリが CLI の後に表示されることを確認
- [ ] 日英切り替えが正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)