### PR TITLE
docs: @xrift/sdk ドキュメントの追加

### DIFF
--- a/docs/sdk/api-reference.md
+++ b/docs/sdk/api-reference.md
@@ -80,45 +80,6 @@ const result = await client.worlds.upload(files, options);
 | `contentHash` | `string` | コンテンツハッシュ |
 | `files` | `UploadFile[]` | アップロードしたファイル |
 
-### `create()`
-
-新しいワールドを作成します。
-
-```typescript
-const world = await client.worlds.create();
-console.log(world.id); // ワールド ID
-```
-
-**戻り値: `CreateWorldResponse`**
-
-| フィールド | 型 | 説明 |
-|-----------|-----|------|
-| `id` | `string` | ワールド ID |
-| `ownerId` | `string` | オーナー ID |
-| `createdAt` | `string` | 作成日時 |
-| `updatedAt` | `string` | 更新日時 |
-
-### `getUploadUrls(worldId, request)`
-
-署名付きアップロード URL を取得します。
-
-```typescript
-const urls = await client.worlds.getUploadUrls(worldId, {
-  name: 'My World',
-  contentHash: 'abc123def456',
-  fileSize: 1024,
-  files: [{ path: 'scene.glb', contentType: 'model/gltf-binary' }],
-});
-```
-
-### `complete(worldId, versionId)`
-
-アップロードの完了を通知します。
-
-```typescript
-await client.worlds.complete(worldId, versionId);
-```
-
 ---
 
 ## ItemsApi
@@ -153,23 +114,6 @@ const result = await client.items.upload(files, options);
 | `versionNumber` | `number` | バージョン番号 |
 | `contentHash` | `string` | コンテンツハッシュ |
 | `files` | `UploadFile[]` | アップロードしたファイル |
-
-### `create()`
-
-新しいアイテムを作成します。
-
-```typescript
-const item = await client.items.create();
-console.log(item.id);
-```
-
-### `getUploadUrls(itemId, request)`
-
-署名付きアップロード URL を取得します。
-
-### `complete(itemId, versionId)`
-
-アップロードの完了を通知します。
 
 ---
 
@@ -281,10 +225,6 @@ getMimeType('unknown.xyz');  // 'application/octet-stream'
 | 型名 | 説明 |
 |------|------|
 | `WorldPermissions` | 権限設定（allowedDomains, allowedCodeRules） |
-| `CreateWorldResponse` | ワールド作成レスポンス |
-| `WorldUploadUrlsRequest` | アップロード URL リクエスト |
-| `WorldUploadUrlsResponse` | アップロード URL レスポンス |
-| `CompleteWorldUploadResponse` | アップロード完了レスポンス |
 | `WorldUploadOptions` | アップロードオプション |
 | `WorldUploadResult` | アップロード結果 |
 
@@ -293,9 +233,5 @@ getMimeType('unknown.xyz');  // 'application/octet-stream'
 | 型名 | 説明 |
 |------|------|
 | `ItemPermissions` | 権限設定（allowedDomains, allowedCodeRules） |
-| `CreateItemResponse` | アイテム作成レスポンス |
-| `ItemUploadUrlsRequest` | アップロード URL リクエスト |
-| `ItemUploadUrlsResponse` | アップロード URL レスポンス |
-| `CompleteItemUploadResponse` | アップロード完了レスポンス |
 | `ItemUploadOptions` | アップロードオプション |
 | `ItemUploadResult` | アップロード結果 |

--- a/docs/sdk/api-reference.md
+++ b/docs/sdk/api-reference.md
@@ -175,6 +175,93 @@ try {
 
 ---
 
+## Config パーサー
+
+`xrift.json` を読み込んで設定オブジェクトを返す関数です。
+
+### `parseWorldConfig(json)`
+
+JSON 文字列をパースしてワールド設定を返します。`"world"` キーが存在しない場合は `XriftSdkError` をスローします。
+
+```typescript
+import { parseWorldConfig } from '@xrift/sdk';
+
+const json = await readFile('xrift.json', 'utf-8');
+const config = parseWorldConfig(json);
+// config.type === 'world'
+// config.distDir, config.name, config.physics, ...
+```
+
+### `parseItemConfig(json)`
+
+JSON 文字列をパースしてアイテム設定を返します。`"item"` キーが存在しない場合は `XriftSdkError` をスローします。
+
+```typescript
+import { parseItemConfig } from '@xrift/sdk';
+
+const json = await readFile('xrift.json', 'utf-8');
+const config = parseItemConfig(json);
+// config.type === 'item'
+// config.distDir, config.name, config.permissions, ...
+```
+
+### `filterFiles(filePaths, ignorePatterns)`
+
+ファイルパスの配列から、ignore パターンにマッチするファイルを除外します。
+
+```typescript
+import { filterFiles, DEFAULT_IGNORE_PATTERNS } from '@xrift/sdk';
+
+const filtered = filterFiles(
+  ['scene.glb', '__federation_shared_abc.js', 'index.html'],
+  DEFAULT_IGNORE_PATTERNS,
+);
+// ['scene.glb', 'index.html']
+```
+
+---
+
+## Node.js ヘルパー
+
+`@xrift/sdk/node` から利用できる Node.js 専用のヘルパー関数です。xrift.json の読み込み → ファイル収集 → アップロードを一括で実行します。
+
+### `uploadWorldFromDirectory(dirPath, options)`
+
+ディレクトリ内の xrift.json を読み込み、ワールドをアップロードします。
+
+```typescript
+import { uploadWorldFromDirectory } from '@xrift/sdk/node';
+
+const result = await uploadWorldFromDirectory('./my-project', {
+  token: process.env.XRIFT_TOKEN!,
+  onProgress: (p) => console.log(`${p.completed}/${p.total}`),
+});
+```
+
+| パラメータ | 型 | 必須 | 説明 |
+|-----------|-----|------|------|
+| `dirPath` | `string` | はい | xrift.json があるディレクトリパス |
+| `options.token` | `string` | はい | API トークン |
+| `options.baseUrl` | `string` | いいえ | API ベース URL |
+| `options.timeout` | `number` | いいえ | タイムアウト (ms) |
+| `options.worldId` | `string` | いいえ | 既存ワールド ID |
+| `options.onProgress` | `(progress: UploadProgress) => void` | いいえ | 進捗コールバック |
+
+### `uploadItemFromDirectory(dirPath, options)`
+
+ディレクトリ内の xrift.json を読み込み、アイテムをアップロードします。
+
+| パラメータ | 型 | 必須 | 説明 |
+|-----------|-----|------|------|
+| `dirPath` | `string` | はい | xrift.json があるディレクトリパス |
+| `options.token` | `string` | はい | API トークン |
+| `options.baseUrl` | `string` | いいえ | API ベース URL |
+| `options.timeout` | `number` | いいえ | タイムアウト (ms) |
+| `options.itemId` | `string` | いいえ | 既存アイテム ID |
+| `options.onProgress` | `(progress: UploadProgress) => void` | いいえ | 進捗コールバック |
+
+---
+
 ## ユーティリティ
 
 ### `calculateContentHash(files, configValues?)`
@@ -207,6 +294,14 @@ getMimeType('unknown.xyz');  // 'application/octet-stream'
 ---
 
 ## 型定義
+
+### Config 型
+
+| 型名 | 説明 |
+|------|------|
+| `XriftWorldConfig` | ワールド設定（type, distDir, name, physics, camera 等） |
+| `XriftItemConfig` | アイテム設定（type, distDir, name, permissions 等） |
+| `XriftConfig` | `XriftWorldConfig \| XriftItemConfig` の union 型 |
 
 ### 共通型
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/sdk/api-reference.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/sdk/api-reference.md
@@ -175,6 +175,93 @@ try {
 
 ---
 
+## Config Parsers
+
+Functions to parse `xrift.json` into configuration objects.
+
+### `parseWorldConfig(json)`
+
+Parses a JSON string and returns a world configuration. Throws `XriftSdkError` if the `"world"` key is missing.
+
+```typescript
+import { parseWorldConfig } from '@xrift/sdk';
+
+const json = await readFile('xrift.json', 'utf-8');
+const config = parseWorldConfig(json);
+// config.type === 'world'
+// config.distDir, config.name, config.physics, ...
+```
+
+### `parseItemConfig(json)`
+
+Parses a JSON string and returns an item configuration. Throws `XriftSdkError` if the `"item"` key is missing.
+
+```typescript
+import { parseItemConfig } from '@xrift/sdk';
+
+const json = await readFile('xrift.json', 'utf-8');
+const config = parseItemConfig(json);
+// config.type === 'item'
+// config.distDir, config.name, config.permissions, ...
+```
+
+### `filterFiles(filePaths, ignorePatterns)`
+
+Filters an array of file paths, excluding files that match any of the ignore patterns.
+
+```typescript
+import { filterFiles, DEFAULT_IGNORE_PATTERNS } from '@xrift/sdk';
+
+const filtered = filterFiles(
+  ['scene.glb', '__federation_shared_abc.js', 'index.html'],
+  DEFAULT_IGNORE_PATTERNS,
+);
+// ['scene.glb', 'index.html']
+```
+
+---
+
+## Node.js Helpers
+
+Helper functions available from `@xrift/sdk/node`. They read xrift.json, collect files, and upload in one call.
+
+### `uploadWorldFromDirectory(dirPath, options)`
+
+Reads xrift.json from a directory and uploads a world.
+
+```typescript
+import { uploadWorldFromDirectory } from '@xrift/sdk/node';
+
+const result = await uploadWorldFromDirectory('./my-project', {
+  token: process.env.XRIFT_TOKEN!,
+  onProgress: (p) => console.log(`${p.completed}/${p.total}`),
+});
+```
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `dirPath` | `string` | Yes | Directory path containing xrift.json |
+| `options.token` | `string` | Yes | API token |
+| `options.baseUrl` | `string` | No | API base URL |
+| `options.timeout` | `number` | No | Timeout (ms) |
+| `options.worldId` | `string` | No | Existing world ID |
+| `options.onProgress` | `(progress: UploadProgress) => void` | No | Progress callback |
+
+### `uploadItemFromDirectory(dirPath, options)`
+
+Reads xrift.json from a directory and uploads an item.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `dirPath` | `string` | Yes | Directory path containing xrift.json |
+| `options.token` | `string` | Yes | API token |
+| `options.baseUrl` | `string` | No | API base URL |
+| `options.timeout` | `number` | No | Timeout (ms) |
+| `options.itemId` | `string` | No | Existing item ID |
+| `options.onProgress` | `(progress: UploadProgress) => void` | No | Progress callback |
+
+---
+
 ## Utilities
 
 ### `calculateContentHash(files, configValues?)`
@@ -207,6 +294,14 @@ Supported extensions: `.glb`, `.gltf`, `.png`, `.jpg`, `.jpeg`, `.webp`, `.json`
 ---
 
 ## Type Definitions
+
+### Config Types
+
+| Type | Description |
+|------|-------------|
+| `XriftWorldConfig` | World configuration (type, distDir, name, physics, camera, etc.) |
+| `XriftItemConfig` | Item configuration (type, distDir, name, permissions, etc.) |
+| `XriftConfig` | Union type: `XriftWorldConfig \| XriftItemConfig` |
 
 ### Common Types
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/sdk/api-reference.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/sdk/api-reference.md
@@ -80,45 +80,6 @@ const result = await client.worlds.upload(files, options);
 | `contentHash` | `string` | Content hash |
 | `files` | `UploadFile[]` | Uploaded files |
 
-### `create()`
-
-Creates a new world.
-
-```typescript
-const world = await client.worlds.create();
-console.log(world.id); // World ID
-```
-
-**Returns: `CreateWorldResponse`**
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `id` | `string` | World ID |
-| `ownerId` | `string` | Owner ID |
-| `createdAt` | `string` | Creation date |
-| `updatedAt` | `string` | Last updated date |
-
-### `getUploadUrls(worldId, request)`
-
-Retrieves signed upload URLs.
-
-```typescript
-const urls = await client.worlds.getUploadUrls(worldId, {
-  name: 'My World',
-  contentHash: 'abc123def456',
-  fileSize: 1024,
-  files: [{ path: 'scene.glb', contentType: 'model/gltf-binary' }],
-});
-```
-
-### `complete(worldId, versionId)`
-
-Notifies upload completion.
-
-```typescript
-await client.worlds.complete(worldId, versionId);
-```
-
 ---
 
 ## ItemsApi
@@ -153,23 +114,6 @@ const result = await client.items.upload(files, options);
 | `versionNumber` | `number` | Version number |
 | `contentHash` | `string` | Content hash |
 | `files` | `UploadFile[]` | Uploaded files |
-
-### `create()`
-
-Creates a new item.
-
-```typescript
-const item = await client.items.create();
-console.log(item.id);
-```
-
-### `getUploadUrls(itemId, request)`
-
-Retrieves signed upload URLs.
-
-### `complete(itemId, versionId)`
-
-Notifies upload completion.
 
 ---
 
@@ -281,10 +225,6 @@ Supported extensions: `.glb`, `.gltf`, `.png`, `.jpg`, `.jpeg`, `.webp`, `.json`
 | Type | Description |
 |------|-------------|
 | `WorldPermissions` | Permission settings (allowedDomains, allowedCodeRules) |
-| `CreateWorldResponse` | World creation response |
-| `WorldUploadUrlsRequest` | Upload URL request |
-| `WorldUploadUrlsResponse` | Upload URL response |
-| `CompleteWorldUploadResponse` | Upload completion response |
 | `WorldUploadOptions` | Upload options |
 | `WorldUploadResult` | Upload result |
 
@@ -293,9 +233,5 @@ Supported extensions: `.glb`, `.gltf`, `.png`, `.jpg`, `.jpeg`, `.webp`, `.json`
 | Type | Description |
 |------|-------------|
 | `ItemPermissions` | Permission settings (allowedDomains, allowedCodeRules) |
-| `CreateItemResponse` | Item creation response |
-| `ItemUploadUrlsRequest` | Upload URL request |
-| `ItemUploadUrlsResponse` | Upload URL response |
-| `CompleteItemUploadResponse` | Upload completion response |
 | `ItemUploadOptions` | Upload options |
 | `ItemUploadResult` | Upload result |


### PR DESCRIPTION
## Summary
- SDK の概要ページと API リファレンスを日本語・英語で追加
- Config パーサー (`parseWorldConfig` / `parseItemConfig`)、`filterFiles`、Node.js ヘルパー (`uploadWorldFromDirectory` / `uploadItemFromDirectory`)、Config 型のドキュメントを追加
- サイドバーに SDK セクションを追加

## Test plan
- [ ] `npm run build` でドキュメントサイトがビルドできることを確認
- [ ] SDK 概要ページと API リファレンスページが正しく表示されることを確認
- [ ] 日本語・英語の両方でページが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)