### PR TITLE
docs: AvatarHeight API ドキュメントを追加

### DIFF
--- a/docs/world-components/components/index.md
+++ b/docs/world-components/components/index.md
@@ -725,6 +725,8 @@ function ParticipantCount() {
 | `remoteUsers` | `User[]` | 他の参加者のユーザー情報の配列 |
 | `getMovement` | `(id: string) => PlayerMovement \| undefined` | 指定ユーザーの位置情報を取得 |
 | `getLocalMovement` | `() => PlayerMovement` | 自分の位置情報を取得 |
+| `getAvatarHeight?` | `(id: string) => AvatarHeight \| undefined` | 指定ユーザーのアバター高さ情報を取得 |
+| `getLocalAvatarHeight?` | `() => AvatarHeight` | 自分のアバター高さ情報を取得 |
 
 #### User 型
 
@@ -752,6 +754,19 @@ interface PlayerMovement {
   vrTracking?: VRTrackingData;
 }
 ```
+
+#### AvatarHeight 型
+
+```typescript
+interface AvatarHeight {
+  height: number;    // アバターの全身の高さ（メートル）
+  eyeHeight: number; // 地面からアバターの目の位置までの高さ（メートル）
+}
+```
+
+:::note[デフォルト値]
+プラットフォーム側が `getAvatarHeight` / `getLocalAvatarHeight` を実装していない場合、デフォルト値として `height: 1.5`、`eyeHeight: 1.35` が返されます。optional プロパティのため、呼び出し時はオプショナルチェーン（`?.`）を使用してください。
+:::
 
 #### useFrame 内での位置情報取得
 
@@ -798,17 +813,20 @@ import { useRef } from 'react';
 import { Group } from 'three';
 import { Text } from '@react-three/drei';
 
-function UserHUD({ user, getMovement }) {
+function UserHUD({ user, getMovement, getAvatarHeight }) {
   const groupRef = useRef<Group>(null);
 
   useFrame(() => {
     const movement = getMovement(user.id);
     if (!movement || !groupRef.current) return;
 
-    // ユーザーの頭の上に配置
+    // アバターの高さを取得し、頭の上にHUDを配置
+    const avatarHeight = getAvatarHeight?.(user.id);
+    const headOffset = (avatarHeight?.height ?? 1.5) + 0.2;
+
     groupRef.current.position.set(
       movement.position.x,
-      movement.position.y + 2,
+      movement.position.y + headOffset,
       movement.position.z
     );
   });
@@ -821,12 +839,12 @@ function UserHUD({ user, getMovement }) {
 }
 
 function UserHUDs() {
-  const { remoteUsers, getMovement } = useUsers();
+  const { remoteUsers, getMovement, getAvatarHeight } = useUsers();
 
   return (
     <>
       {remoteUsers.map(user => (
-        <UserHUD key={user.id} user={user} getMovement={getMovement} />
+        <UserHUD key={user.id} user={user} getMovement={getMovement} getAvatarHeight={getAvatarHeight} />
       ))}
     </>
   );

--- a/i18n/en/docusaurus-plugin-content-docs/current/world-components/components/index.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/world-components/components/index.md
@@ -810,6 +810,8 @@ function ParticipantCount() {
 | `remoteUsers` | `User[]` | Array of information about other participants |
 | `getMovement` | `(id: string) => PlayerMovement \| undefined` | Retrieve location information of a specific user |
 | `getLocalMovement` | `() => PlayerMovement` | Retrieve your own location information |
+| `getAvatarHeight?` | `(id: string) => AvatarHeight \| undefined` | Retrieve avatar height information of a specific user |
+| `getLocalAvatarHeight?` | `() => AvatarHeight` | Retrieve your own avatar height information |
 
 #### User Type
 
@@ -837,6 +839,19 @@ interface PlayerMovement {
   vrTracking?: VRTrackingData;
 }
 ```
+
+#### AvatarHeight Type
+
+```typescript
+interface AvatarHeight {
+  height: number;    // Full height of the avatar (meters)
+  eyeHeight: number; // Height from ground to the avatar's eye position (meters)
+}
+```
+
+:::note[Default Values]
+If the platform does not implement `getAvatarHeight` / `getLocalAvatarHeight`, default values of `height: 1.5` and `eyeHeight: 1.35` are returned. Since these are optional properties, use optional chaining (`?.`) when calling them.
+:::
 
 #### Retrieving Position in useFrame
 
@@ -883,17 +898,20 @@ import { useRef } from 'react';
 import { Group } from 'three';
 import { Text } from '@react-three/drei';
 
-function UserHUD({ user, getMovement }) {
+function UserHUD({ user, getMovement, getAvatarHeight }) {
   const groupRef = useRef<Group>(null);
 
   useFrame(() => {
     const movement = getMovement(user.id);
     if (!movement || !groupRef.current) return;
 
-    // Place above the user's head
+    // Get the avatar's height and place HUD above the head
+    const avatarHeight = getAvatarHeight?.(user.id);
+    const headOffset = (avatarHeight?.height ?? 1.5) + 0.2;
+
     groupRef.current.position.set(
       movement.position.x,
-      movement.position.y + 2,
+      movement.position.y + headOffset,
       movement.position.z
     );
   });
@@ -906,12 +924,12 @@ function UserHUD({ user, getMovement }) {
 }
 
 function UserHUDs() {
-  const { remoteUsers, getMovement } = useUsers();
+  const { remoteUsers, getMovement, getAvatarHeight } = useUsers();
 
   return (
     <>
       {remoteUsers.map(user => (
-        <UserHUD key={user.id} user={user} getMovement={getMovement} />
+        <UserHUD key={user.id} user={user} getMovement={getMovement} getAvatarHeight={getAvatarHeight} />
       ))}
     </>
   );


### PR DESCRIPTION
## Summary
- `useUsers` の戻り値テーブルに `getAvatarHeight` / `getLocalAvatarHeight` を追加
- `AvatarHeight` 型定義セクションを追加
- ユーザー頭上HUDのユースケースをアバター高さを使った例に更新
- 日本語・英語の両方を更新

対応: WebXR-JP/xrift-world-components#166

🤖 Generated with [Claude Code](https://claude.com/claude-code)