### PR TITLE
docs: ワールド・アイテム共通のページを「共通ガイド」カテゴリに移動

### DIFF
--- a/docs/guides/shared-dependencies.md
+++ b/docs/guides/shared-dependencies.md
@@ -1,10 +1,10 @@
 ---
-sidebar_position: 4
+sidebar_position: 2
 ---
 
 # Shared パッケージ一覧
 
-ワールドの `vite.config.ts` で Module Federation の `shared` に宣言したパッケージは、ホスト（xrift.net）側の shared から解決されます。このページでは、ホスト側で shared として提供されているパッケージの一覧を掲載しています。
+ワールド・アイテムの `vite.config.ts` で Module Federation の `shared` に宣言したパッケージは、ホスト（xrift.net）側の shared から解決されます。このページでは、ホスト側で shared として提供されているパッケージの一覧を掲載しています。
 
 ## パッケージ一覧
 
@@ -29,16 +29,16 @@ sidebar_position: 4
 
 `three/addons` バレルファイル全体を shared にすると Lottie 由来の `eval` がバンドルに含まれるため、**サブパス単位**で shared にしています。
 
-ワールド側でも `three/addons/loaders/DRACOLoader.js` のようにサブパスで shared を宣言する必要があります。
+ワールド・アイテム側でも `three/addons/loaders/DRACOLoader.js` のようにサブパスで shared を宣言する必要があります。
 
 :::caution
 `three/addons` をそのまま shared に指定しないでください。サブパス単位で指定する必要があります。
 :::
 
-## ワールド側の設定例
+## 設定例
 
 ```js
-// vite.config.ts (ワールド側)
+// vite.config.ts
 import federation from '@originjs/vite-plugin-federation';
 
 export default defineConfig({

--- a/docs/guides/triplex.md
+++ b/docs/guides/triplex.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 1
 ---
 
 # Triplex（ビジュアルエディタ）
@@ -14,9 +14,9 @@ sidebar_position: 3
 
 ## XRift プロジェクトでの使い方
 
-XRift のワールドは React Three Fiber で構築されているため、Triplex をそのまま活用できます。
+XRift のワールド・アイテムはどちらも React Three Fiber で構築されているため、Triplex をそのまま活用できます。
 
-1. VS Code でワールドプロジェクトを開く
+1. VS Code で XRift プロジェクト（ワールド / アイテム）を開く
 2. エクスポートされたコンポーネントを含む `.tsx` ファイルを開く
 3. コンポーネント上部に表示される「Open in Triplex」CodeLens をクリック
 4. ビジュアルエディタ上でコンポーネントの位置・回転・スケールを調整

--- a/docs/world-components/components/index.md
+++ b/docs/world-components/components/index.md
@@ -1,10 +1,10 @@
 ---
-sidebar_position: 1
+sidebar_position: 3
 ---
 
 # API リファレンス
 
-xrift-world-components で提供されるコンポーネント、フック、定数の一覧です。
+`@xrift/world-components` で提供されるコンポーネント、フック、定数の一覧です。ワールド開発だけでなくアイテム開発からも利用できます（`SpawnPoint` / `DevEnvironment` / `useSpawnPoint` などワールド専用のものは各項目に注記しています）。
 
 ## コンポーネント
 
@@ -190,6 +190,10 @@ import { ScreenShareDisplay } from '@xrift/world-components';
 
 ワールド内でプレイヤーが出現する地点を指定します。
 
+:::caution[ワールド専用]
+`SpawnPoint` はワールドレベルのスポーン位置を設定するコンポーネントです。アイテム内で使用することは想定されていません。
+:::
+
 ```tsx
 import { SpawnPoint } from '@xrift/world-components';
 
@@ -369,8 +373,8 @@ export const MyWorld = () => {
 
 ローカル開発用の環境を提供するコンポーネントです。ワールドテンプレートの `dev.tsx` で使用します。
 
-:::caution[使用場所について]
-このコンポーネントはワールド開発プロジェクトで `npm run dev` を実行した際のローカル確認用です。`World.tsx` などの実際のワールドコンテンツ内では使用しないでください。
+:::caution[ワールド専用]
+`DevEnvironment` はワールド開発プロジェクトで `npm run dev` を実行した際のローカル確認用です。`World.tsx` などの実際のワールドコンテンツ内では使用しないでください。また、アイテム開発では使用しません（アイテムテンプレートは独自の `dev.tsx` を持ちます）。
 :::
 
 ```tsx

--- a/i18n/en/docusaurus-plugin-content-docs/current.json
+++ b/i18n/en/docusaurus-plugin-content-docs/current.json
@@ -15,6 +15,10 @@
     "message": "Item Development",
     "description": "The label for category 'アイテム開発' in sidebar 'docsSidebar'"
   },
+  "sidebar.docsSidebar.category.共通ガイド": {
+    "message": "Common Guides",
+    "description": "The label for category '共通ガイド' in sidebar 'docsSidebar'"
+  },
   "sidebar.docsSidebar.category.CLI (xrift-cli)": {
     "message": "CLI (xrift-cli)",
     "description": "The label for category 'CLI (xrift-cli)' in sidebar 'docsSidebar'"

--- a/i18n/en/docusaurus-plugin-content-docs/current/guides/shared-dependencies.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/guides/shared-dependencies.md
@@ -1,10 +1,10 @@
 ---
-sidebar_position: 4
+sidebar_position: 2
 ---
 
 # Shared Packages
 
-Packages declared in the `shared` section of Module Federation in your world's `vite.config.ts` are resolved from the host (xrift.net) side. This page lists all packages provided as shared by the host.
+Packages declared in the `shared` section of Module Federation in your world or item's `vite.config.ts` are resolved from the host (xrift.net) side. This page lists all packages provided as shared by the host.
 
 ## Package List
 
@@ -29,16 +29,16 @@ Packages declared in the `shared` section of Module Federation in your world's `
 
 Sharing the entire `three/addons` barrel file would include `eval` from Lottie in the bundle, so packages are shared at the **subpath level**.
 
-You also need to declare shared packages using subpaths like `three/addons/loaders/DRACOLoader.js` on the world side.
+You also need to declare shared packages using subpaths like `three/addons/loaders/DRACOLoader.js` on the world or item side.
 
 :::caution
 Do not specify `three/addons` directly as shared. You must specify it at the subpath level.
 :::
 
-## World-side Configuration Example
+## Configuration Example
 
 ```js
-// vite.config.ts (world side)
+// vite.config.ts
 import federation from '@originjs/vite-plugin-federation';
 
 export default defineConfig({

--- a/i18n/en/docusaurus-plugin-content-docs/current/guides/triplex.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/guides/triplex.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 1
 ---
 
 # Triplex (Visual Editor)
@@ -14,9 +14,9 @@ Install from the [VS Code Marketplace](https://marketplace.visualstudio.com/item
 
 ## Using Triplex with XRift Projects
 
-Since XRift worlds are built with React Three Fiber, you can use Triplex directly.
+Both XRift worlds and items are built with React Three Fiber, so you can use Triplex directly.
 
-1. Open the world project in VS Code
+1. Open an XRift project (world or item) in VS Code
 2. Open a `.tsx` file containing an exported component
 3. Click the "Open in Triplex" CodeLens that appears above the component
 4. Adjust position, rotation, and scale of components in the visual editor

--- a/i18n/en/docusaurus-plugin-content-docs/current/world-components/components/index.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/world-components/components/index.md
@@ -1,10 +1,10 @@
 ---
-sidebar_position: 1
+sidebar_position: 3
 ---
 
 # API Reference
 
-A list of components, hooks, and constants provided by xrift-world-components.
+A list of components, hooks, and constants provided by `@xrift/world-components`. These can be used from both world and item development (world-only items such as `SpawnPoint` / `DevEnvironment` / `useSpawnPoint` are called out on each entry).
 
 ## Components
 
@@ -213,6 +213,10 @@ Only one screen can be shared per world. While it is possible to place multiple 
 
 Specifies the point where players spawn in the world.
 
+:::caution[World-only]
+`SpawnPoint` sets the world-level spawn location. It is not intended to be used from within an item.
+:::
+
 ```tsx
 import { SpawnPoint } from '@xrift/world-components';
 
@@ -392,8 +396,8 @@ export const MyWorld = () => {
 
 A component that provides a local development environment. Used in the world template's `dev.tsx`.
 
-:::caution[Usage]
-This component is for local preview when running `npm run dev` in a world development project. Do not use it inside actual world content such as `World.tsx`.
+:::caution[World-only]
+`DevEnvironment` is for local preview when running `npm run dev` in a world development project. Do not use it inside actual world content such as `World.tsx`. It is also not used for item development (the item template uses its own `dev.tsx`).
 :::
 
 ```tsx

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -17,9 +17,6 @@ const sidebars: SidebarsConfig = {
       items: [
         'guides/create-first-world',
         'guides/configuration',
-        'guides/triplex',
-        'guides/shared-dependencies',
-        'world-components/components/index',
       ],
     },
     {
@@ -28,6 +25,15 @@ const sidebars: SidebarsConfig = {
       items: [
         'item/create-first-item',
         'item/configuration',
+      ],
+    },
+    {
+      type: 'category',
+      label: '共通ガイド',
+      items: [
+        'guides/triplex',
+        'guides/shared-dependencies',
+        'world-components/components/index',
       ],
     },
     {


### PR DESCRIPTION
## Summary

「ワールド開発」カテゴリに入っていた Triplex / Shared パッケージ一覧 / API リファレンスは、実際にはアイテム開発でもそのまま使える内容なので、新規「共通ガイド」カテゴリに集約しました。アイテム開発者からも見つけやすくなります。

### サイドバー構成（変更後）

- Getting Started
- ワールド開発
  - 最初のワールドを作成する
  - xrift.json 設定
- アイテム開発
  - 最初のアイテムを作成する
  - xrift.json 設定
- **共通ガイド** ← NEW
  - Triplex（ビジュアルエディタ）
  - Shared パッケージ一覧
  - API リファレンス
- CLI (xrift-cli)
- SDK (@xrift/sdk)

### 変更点

- `sidebars.ts`: 「共通ガイド」カテゴリを追加し、該当 3 ページを移動
- `i18n/en/.../current.json`: 「共通ガイド」の英訳 `Common Guides` を追加
- `docs/guides/triplex.md`: 「XRift のワールドは React Three Fiber…」→「ワールド・アイテムはどちらも React Three Fiber…」など汎用化
- `docs/guides/shared-dependencies.md`: 「ワールドの vite.config.ts」→「ワールド・アイテムの vite.config.ts」など汎用化
- `docs/world-components/components/index.md`:
  - 冒頭にアイテム開発からも利用可能である旨を追記
  - `SpawnPoint` / `DevEnvironment` にワールド専用の caution を追加
- 日本語・英語の両ロケール対応

## Test plan

- [ ] `npm run build` が両ロケールで成功することを確認（ローカルで確認済み）
- [ ] サイドバーに「共通ガイド」カテゴリが表示され、Triplex / Shared パッケージ一覧 / API リファレンスが並ぶことを確認
- [ ] 英語ロケールでもカテゴリ名が「Common Guides」になることを確認
- [ ] API リファレンスで `SpawnPoint` / `DevEnvironment` に「ワールド専用」の注記が表示されることを確認
- [ ] 既存リンク（他ページからの `/guides/triplex` 等）が正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)