### PR TITLE
docs: useFileInput hooks のドキュメントを追加

### DIFF
--- a/docs/world-components/components/index.md
+++ b/docs/world-components/components/index.md
@@ -1295,6 +1295,100 @@ type FontLocale = 'ja'
 
 ---
 
+### useFileInput
+
+ファイル選択ダイアログを表示するフックです。3Dオブジェクトのクリックをトリガーに、ブラウザのファイルピッカー（ドラッグ&ドロップ対応のオーバーレイUI）を開くことができます。
+
+```tsx
+import { useFileInput } from '@xrift/world-components';
+
+function MyComponent() {
+  const { requestFileInput } = useFileInput();
+
+  const handleClick = () => {
+    requestFileInput({
+      id: 'avatar-upload',
+      accept: '.vrm',
+      maxSize: 30 * 1024 * 1024,
+      onSelect: (files) => console.log('選択:', files),
+    });
+  };
+}
+```
+
+#### 戻り値
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `requestFileInput` | `(request: FileInputRequest) => void` | ファイル選択ダイアログを表示する |
+
+#### FileInputRequest
+
+| Property | Type | 必須 | Description |
+|----------|------|------|-------------|
+| `id` | `string` | Yes | 入力の一意なID |
+| `accept` | `string` | No | 受け入れるファイルタイプ（例: `'.vrm'`, `'image/*'`） |
+| `multiple` | `boolean` | No | 複数ファイル選択を許可するか |
+| `maxSize` | `number` | No | 最大ファイルサイズ（バイト単位） |
+| `onSelect` | `(files: File[]) => void` | Yes | ファイル選択完了時のコールバック |
+| `onCancel` | `() => void` | No | キャンセル時のコールバック |
+| `onError` | `(error: FileInputError) => void` | No | エラー時のコールバック |
+
+#### FileInputError
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `type` | `'file_too_large' \| 'invalid_type'` | エラー種別 |
+| `message` | `string` | エラーメッセージ |
+
+#### 使用例
+
+##### VRMファイルのアップロード
+
+```tsx
+import { useFileInput, Interactable } from '@xrift/world-components'
+import { useState } from 'react'
+
+function AvatarUploader() {
+  const { requestFileInput } = useFileInput()
+  const [fileName, setFileName] = useState('')
+
+  const handleClick = () => {
+    requestFileInput({
+      id: 'avatar-upload',
+      accept: '.vrm',
+      maxSize: 30 * 1024 * 1024, // 30MB
+      onSelect: (files) => {
+        setFileName(files[0].name)
+        // ファイルをアップロードする処理...
+      },
+      onError: (error) => {
+        console.error(error.message)
+      },
+    })
+  }
+
+  return (
+    <Interactable id="upload-button" onInteract={handleClick} interactionText="アバター変更">
+      <mesh>
+        <boxGeometry args={[1, 0.5, 0.1]} />
+        <meshStandardMaterial color="#7b2d8b" />
+      </mesh>
+    </Interactable>
+  )
+}
+```
+
+:::tip[ドラッグ&ドロップ対応]
+ファイル選択オーバーレイはドラッグ&ドロップにも対応しています。ユーザーはクリックでファイルを選択するか、ファイルをドロップゾーンにドラッグして追加できます。
+:::
+
+:::note[VRセッション中の動作]
+VRセッション中にファイル選択がリクエストされた場合、自動的にVRセッションが終了してからファイルピッカーが表示されます。
+:::
+
+---
+
 ## 定数
 
 ### LAYERS

--- a/i18n/en/docusaurus-plugin-content-docs/current/world-components/components/index.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/world-components/components/index.md
@@ -1300,6 +1300,100 @@ Renamed from `useAudioVolume` to `useVoiceVolumeOverride` in v0.34.0. The old na
 
 ---
 
+### useFileInput
+
+A hook for displaying a file picker dialog. Allows opening a browser file picker (with drag & drop overlay UI) triggered by clicking a 3D object.
+
+```tsx
+import { useFileInput } from '@xrift/world-components';
+
+function MyComponent() {
+  const { requestFileInput } = useFileInput();
+
+  const handleClick = () => {
+    requestFileInput({
+      id: 'avatar-upload',
+      accept: '.vrm',
+      maxSize: 30 * 1024 * 1024,
+      onSelect: (files) => console.log('Selected:', files),
+    });
+  };
+}
+```
+
+#### Return Value
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `requestFileInput` | `(request: FileInputRequest) => void` | Display the file picker dialog |
+
+#### FileInputRequest
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `id` | `string` | Yes | Unique identifier for the input |
+| `accept` | `string` | No | Accepted file types (e.g. `'.vrm'`, `'image/*'`) |
+| `multiple` | `boolean` | No | Allow multiple file selection |
+| `maxSize` | `number` | No | Maximum file size in bytes |
+| `onSelect` | `(files: File[]) => void` | Yes | Callback when files are selected |
+| `onCancel` | `() => void` | No | Callback when cancelled |
+| `onError` | `(error: FileInputError) => void` | No | Callback on error |
+
+#### FileInputError
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `type` | `'file_too_large' \| 'invalid_type'` | Error type |
+| `message` | `string` | Error message |
+
+#### Usage Examples
+
+##### VRM File Upload
+
+```tsx
+import { useFileInput, Interactable } from '@xrift/world-components'
+import { useState } from 'react'
+
+function AvatarUploader() {
+  const { requestFileInput } = useFileInput()
+  const [fileName, setFileName] = useState('')
+
+  const handleClick = () => {
+    requestFileInput({
+      id: 'avatar-upload',
+      accept: '.vrm',
+      maxSize: 30 * 1024 * 1024, // 30MB
+      onSelect: (files) => {
+        setFileName(files[0].name)
+        // Upload file...
+      },
+      onError: (error) => {
+        console.error(error.message)
+      },
+    })
+  }
+
+  return (
+    <Interactable id="upload-button" onInteract={handleClick} interactionText="Change Avatar">
+      <mesh>
+        <boxGeometry args={[1, 0.5, 0.1]} />
+        <meshStandardMaterial color="#7b2d8b" />
+      </mesh>
+    </Interactable>
+  )
+}
+```
+
+:::tip[Drag & Drop Support]
+The file picker overlay also supports drag & drop. Users can either click to browse for files or drag files onto the drop zone.
+:::
+
+:::note[Behavior During VR Sessions]
+When a file input is requested during a VR session, the VR session is automatically ended before the file picker is displayed.
+:::
+
+---
+
 ## Constants
 
 ### LAYERS


### PR DESCRIPTION
## Summary
- `useFileInput` hooks の API リファレンスを world-components ドキュメントに追加
- FileInputRequest / FileInputError の型説明、使用例、Tips を記載

## 関連PR
- world-components: https://github.com/WebXR-JP/xrift-world-components/pull/169
- xrift-frontend: https://github.com/WebXR-JP/xrift-frontend/pull/1215

🤖 Generated with [Claude Code](https://claude.com/claude-code)