### PR TITLE
docs: useItem hook のドキュメントを追加

### DIFF
--- a/docs/world-components/components/index.md
+++ b/docs/world-components/components/index.md
@@ -1485,6 +1485,51 @@ function SharedFileUploader() {
 
 ---
 
+### useItem
+
+配置されたアイテムの固有IDを取得するフックです。同じアイテムが複数配置された場合でも、配置ごとに異なるIDが返されます。
+
+```tsx
+import { useItem } from '@xrift/world-components';
+
+function MyItem() {
+  const { id } = useItem();
+  // id は配置ごとにユニーク
+}
+```
+
+#### 戻り値
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `id` | `string` | 配置オブジェクトの固有ID（UUID） |
+
+:::note
+`useItem` は `ItemProvider` 内でのみ使用可能です。Provider 外で呼び出すと例外がスローされます。プラットフォームが `ItemProvider` を自動的に提供するため、アイテム開発者が Provider を設定する必要はありません。
+:::
+
+##### 配置ごとのステート管理
+
+```tsx
+import { useItem, useInstanceState } from '@xrift/world-components';
+
+function VotingBox() {
+  const { id } = useItem();
+  const [votes, setVotes] = useInstanceState(`votes-${id}`, 0);
+
+  return (
+    <Interactable id={`vote-${id}`} onInteract={() => setVotes(votes + 1)}>
+      <mesh>
+        <boxGeometry args={[1, 1, 0.2]} />
+        <meshStandardMaterial color="green" />
+      </mesh>
+    </Interactable>
+  );
+}
+```
+
+---
+
 ## 定数
 
 ### LAYERS

--- a/i18n/en/docusaurus-plugin-content-docs/current/world-components/components/index.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/world-components/components/index.md
@@ -1490,6 +1490,49 @@ function SharedFileUploader() {
 
 ---
 
+### useItem
+
+A hook that retrieves the unique ID of a placed item. Even when the same item is placed multiple times, each placement returns a different ID.
+
+```tsx
+import { useItem } from '@xrift/world-components';
+
+function MyItem() {
+  const { id } = useItem();
+  // id is unique per placement
+}
+```
+
+#### Returns
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `id` | `string` | Unique ID of the placed object (UUID) |
+
+**Note:** `useItem` can only be used within an `ItemProvider`. Calling it outside the provider will throw an error. The platform automatically provides the `ItemProvider`, so item developers do not need to set up the provider themselves.
+
+##### Per-placement state management
+
+```tsx
+import { useItem, useInstanceState } from '@xrift/world-components';
+
+function VotingBox() {
+  const { id } = useItem();
+  const [votes, setVotes] = useInstanceState(`votes-${id}`, 0);
+
+  return (
+    <Interactable id={`vote-${id}`} onInteract={() => setVotes(votes + 1)}>
+      <mesh>
+        <boxGeometry args={[1, 1, 0.2]} />
+        <meshStandardMaterial color="green" />
+      </mesh>
+    </Interactable>
+  );
+}
+```
+
+---
+
 ## Constants
 
 ### LAYERS


### PR DESCRIPTION
## Summary
- `useItem` hook のドキュメントを日本語・英語の両方に追加
- 配置ごとの固有ID取得、`useInstanceState` と組み合わせた配置別ステート管理の例を記載

## 関連PR
- WebXR-JP/xrift-world-components#171
- WebXR-JP/xrift-frontend#1232

🤖 Generated with [Claude Code](https://claude.com/claude-code)