### PR TITLE
docs: Grabbable コンポーネントのドキュメントを追加

### DIFF
--- a/docs/world-components/components/index.md
+++ b/docs/world-components/components/index.md
@@ -42,6 +42,8 @@ import { Interactable } from '@xrift/world-components';
 
 配下のメッシュを `LAYERS.GRABBABLE`（レイヤー14）に載せ、掴む土台（レイキャスト・追従・確定）はプラットフォーム側が担います。開発時は `DevEnvironment` に同梱のシステムで動作確認できます。
 
+`transform` と `onMove` の座標は、`Grabbable` を置いた**親のローカル空間**（通常の `position` prop と同じ）で扱われます。変形された親グループの下にネストしても内部でワールド座標へ変換されるため、離した位置がズレることはありません。
+
 ```tsx
 import { useState } from 'react';
 import { Grabbable, type GrabbableTransform } from '@xrift/world-components';
@@ -73,8 +75,8 @@ function GrabbableBall() {
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
 | `id` | `string` | - | 一意の識別子（必須） |
-| `transform` | `GrabbableTransform` | - | 対象の現在姿勢（必須）。ルート group に適用されるため、子はローカル座標で書く |
-| `onMove` | `(transform: GrabResultTransform) => void` | - | 離した（確定）ときに新しい姿勢を受け取る（必須）。state に反映して `transform` を更新する |
+| `transform` | `GrabbableTransform` | - | 対象の現在姿勢（必須）。親のローカル座標で指定し、ルート group に適用される（子は原点基準で書く） |
+| `onMove` | `(transform: GrabResultTransform) => void` | - | 離した（確定）ときに新しい姿勢を受け取る（必須）。`transform` と同じ親ローカル座標で返るので、state に反映して `transform` を更新する |
 | `renderGhost` | `() => ReactNode` | - | 掴み中に表示するゴースト（半透明・物理なし）をローカル座標で返す。省略時は `children` を流用 |
 | `enabled` | `boolean` | `true` | 掴めるかどうか（`false` で一時的に無効化） |
 | `children` | `ReactNode` | - | 掴む対象のオブジェクト（ローカル座標で書く・必須） |
@@ -83,7 +85,7 @@ function GrabbableBall() {
 
 ```typescript
 interface GrabbableTransform {
-  position: { x: number; y: number; z: number };  // ワールド座標
+  position: { x: number; y: number; z: number };  // 親のローカル座標（通常の position prop と同じ）
   rotation: { x: number; y: number; z: number };  // オイラー角（ラジアン）
   scale?: number;                                   // 均一スケール（省略時は 1）
 }

--- a/docs/world-components/components/index.md
+++ b/docs/world-components/components/index.md
@@ -36,6 +36,74 @@ import { Interactable } from '@xrift/world-components';
 
 ---
 
+### Grabbable
+
+オブジェクトを「掴める」と宣言するラッパーコンポーネントです。`Interactable` と同じく、囲んだ対象を明示的にオプトインさせます。プレイヤーは掴んだオブジェクトを視点前方に浮かせて運び、任意の位置に置くことができます。
+
+配下のメッシュを `LAYERS.GRABBABLE`（レイヤー14）に載せ、掴む土台（レイキャスト・追従・確定）はプラットフォーム側が担います。開発時は `DevEnvironment` に同梱のシステムで動作確認できます。
+
+```tsx
+import { useState } from 'react';
+import { Grabbable, type GrabbableTransform } from '@xrift/world-components';
+
+function GrabbableBall() {
+  const [transform, setTransform] = useState<GrabbableTransform>({
+    position: { x: 2, y: 0.5, z: -2 },
+    rotation: { x: 0, y: 0, z: 0 },
+  });
+
+  return (
+    <Grabbable
+      id="ball"
+      transform={transform}
+      onMove={(next) => setTransform((prev) => ({ ...prev, ...next }))}
+    >
+      {/* 子はローカル座標（原点基準）で書く */}
+      <mesh>
+        <sphereGeometry args={[0.3]} />
+        <meshStandardMaterial color="gold" />
+      </mesh>
+    </Grabbable>
+  );
+}
+```
+
+#### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `id` | `string` | - | 一意の識別子（必須） |
+| `transform` | `GrabbableTransform` | - | 対象の現在姿勢（必須）。ルート group に適用されるため、子はローカル座標で書く |
+| `onMove` | `(transform: GrabResultTransform) => void` | - | 離した（確定）ときに新しい姿勢を受け取る（必須）。state に反映して `transform` を更新する |
+| `renderGhost` | `() => ReactNode` | - | 掴み中に表示するゴースト（半透明・物理なし）をローカル座標で返す。省略時は `children` を流用 |
+| `enabled` | `boolean` | `true` | 掴めるかどうか（`false` で一時的に無効化） |
+| `children` | `ReactNode` | - | 掴む対象のオブジェクト（ローカル座標で書く・必須） |
+
+#### GrabbableTransform / GrabResultTransform
+
+```typescript
+interface GrabbableTransform {
+  position: { x: number; y: number; z: number };  // ワールド座標
+  rotation: { x: number; y: number; z: number };  // オイラー角（ラジアン）
+  scale?: number;                                   // 均一スケール（省略時は 1）
+}
+
+interface GrabResultTransform {
+  position: { x: number; y: number; z: number };
+  rotation: { x: number; y: number; z: number };
+}
+```
+
+:::caution[物理を含む場合]
+子に物理（`RigidBody` など）を含む場合、`renderGhost` に**物理なし版**を必ず指定してください。省略すると `children` がそのままゴーストとして描画され、掴み中に実体とゴーストのコライダーが重複します。
+:::
+
+:::note[操作方法]
+掴む操作はデスクトップ（ポインターロック＋中央クロスヘア）が前提です。`DevEnvironment` では **G** で掴む/置く、マウスホイールで距離調整、クリックで確定、**Esc**（ポインターロック解除）でキャンセルできます。
+:::
+
+---
+
 ### Mirror
 
 リアルタイム反射面を作成します。
@@ -429,6 +497,7 @@ createRoot(rootElement).render(
 - **ファーストパーソンプレイヤー**: 物理ベースのWASD移動・ジャンプ・リスポーン
 - **視点操作**: PointerLockControls による視点操作
 - **インタラクション**: INTERACTABLE レイヤーへのレイキャスト + クリックインタラクション
+- **掴む（Grabbable）**: GRABBABLE レイヤーへのレイキャスト + 視点前方への追従・確定
 - **クロスヘアUI**: 画面中央のクロスヘア（ヒット時ハイライト）
 - **案内UI**: ポインターロック状態の案内UI
 - **操作説明UI**: 操作方法を表示するUI
@@ -437,10 +506,12 @@ createRoot(rootElement).render(
 
 | 操作 | 説明 |
 |------|------|
-| クリック | ポインターロック開始 / インタラクト |
+| クリック | ポインターロック開始 / インタラクト / 掴み中は確定 |
 | WASD / 矢印キー | 移動 |
 | Space / E | ジャンプ |
-| ESC | ポインターロック解除 |
+| G | 掴む / 置く（`Grabbable` 対象） |
+| マウスホイール | 掴み中の距離調整 |
+| ESC | ポインターロック解除（掴み中はキャンセル） |
 
 :::note[前提条件]
 `@react-three/rapier`（`^2.0.0`）のインストールが必要です（optional peerDependency）。
@@ -1546,12 +1617,13 @@ import { LAYERS } from '@xrift/world-components';
 | `LAYERS.FIRST_PERSON_ONLY` | `9` | 一人称視点のみ表示（VRMFirstPerson用） |
 | `LAYERS.THIRD_PERSON_ONLY` | `10` | 三人称視点のみ表示（VRMFirstPerson用） |
 | `LAYERS.INTERACTABLE` | `11` | インタラクト可能オブジェクト（Raycast対象） |
+| `LAYERS.GRABBABLE` | `14` | 掴めるオブジェクト（`Grabbable` のRaycast対象） |
 
 #### 関連する型
 
 ```typescript
-type LayerName = 'DEFAULT' | 'FIRST_PERSON_ONLY' | 'THIRD_PERSON_ONLY' | 'INTERACTABLE';
-type LayerNumber = 0 | 9 | 10 | 11;
+type LayerName = 'DEFAULT' | 'FIRST_PERSON_ONLY' | 'THIRD_PERSON_ONLY' | 'INTERACTABLE' | 'GRABBABLE';
+type LayerNumber = 0 | 9 | 10 | 11 | 14;
 ```
 
 #### ユースケース

--- a/i18n/en/docusaurus-plugin-content-docs/current/world-components/components/index.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/world-components/components/index.md
@@ -42,6 +42,8 @@ A wrapper component that declares an object as "grabbable". Like `Interactable`,
 
 It puts child meshes on `LAYERS.GRABBABLE` (layer 14). The grabbing foundation (raycasting, following, committing) is handled by the platform. During development, you can test it with the system bundled in `DevEnvironment`.
 
+The coordinates of `transform` and `onMove` are in the **local space of the parent** where you place the `Grabbable` (the same as a normal `position` prop). Even when nested under a transformed parent group, they are converted to/from world coordinates internally, so the release position never drifts.
+
 ```tsx
 import { useState } from 'react';
 import { Grabbable, type GrabbableTransform } from '@xrift/world-components';
@@ -73,8 +75,8 @@ function GrabbableBall() {
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
 | `id` | `string` | - | Unique identifier (Required) |
-| `transform` | `GrabbableTransform` | - | Current pose of the object (Required). Applied to the root group, so children are written in local coordinates |
-| `onMove` | `(transform: GrabResultTransform) => void` | - | Receives the new pose when released/committed (Required). Reflect it in state to update `transform` |
+| `transform` | `GrabbableTransform` | - | Current pose of the object (Required). Specified in the parent's local coordinates and applied to the root group (children are written relative to the origin) |
+| `onMove` | `(transform: GrabResultTransform) => void` | - | Receives the new pose when released/committed (Required). Returned in the same parent-local coordinates as `transform`, so reflect it in state to update `transform` |
 | `renderGhost` | `() => ReactNode` | - | Returns the ghost (semi-transparent, no physics) shown while grabbing, in local coordinates. Falls back to `children` if omitted |
 | `enabled` | `boolean` | `true` | Whether it is grabbable (`false` to temporarily disable) |
 | `children` | `ReactNode` | - | The grabbable object (written in local coordinates, Required) |
@@ -83,7 +85,7 @@ function GrabbableBall() {
 
 ```typescript
 interface GrabbableTransform {
-  position: { x: number; y: number; z: number };  // World coordinates
+  position: { x: number; y: number; z: number };  // Parent-local coordinates (same as a normal position prop)
   rotation: { x: number; y: number; z: number };  // Euler angles (radians)
   scale?: number;                                   // Uniform scale (defaults to 1)
 }

--- a/i18n/en/docusaurus-plugin-content-docs/current/world-components/components/index.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/world-components/components/index.md
@@ -36,6 +36,74 @@ import { Interactable } from '@xrift/world-components';
 
 ---
 
+### Grabbable
+
+A wrapper component that declares an object as "grabbable". Like `Interactable`, it makes the wrapped object explicitly opt in. Players can grab the object, float it in front of their view, and place it anywhere.
+
+It puts child meshes on `LAYERS.GRABBABLE` (layer 14). The grabbing foundation (raycasting, following, committing) is handled by the platform. During development, you can test it with the system bundled in `DevEnvironment`.
+
+```tsx
+import { useState } from 'react';
+import { Grabbable, type GrabbableTransform } from '@xrift/world-components';
+
+function GrabbableBall() {
+  const [transform, setTransform] = useState<GrabbableTransform>({
+    position: { x: 2, y: 0.5, z: -2 },
+    rotation: { x: 0, y: 0, z: 0 },
+  });
+
+  return (
+    <Grabbable
+      id="ball"
+      transform={transform}
+      onMove={(next) => setTransform((prev) => ({ ...prev, ...next }))}
+    >
+      {/* Write children in local coordinates (relative to origin) */}
+      <mesh>
+        <sphereGeometry args={[0.3]} />
+        <meshStandardMaterial color="gold" />
+      </mesh>
+    </Grabbable>
+  );
+}
+```
+
+#### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `id` | `string` | - | Unique identifier (Required) |
+| `transform` | `GrabbableTransform` | - | Current pose of the object (Required). Applied to the root group, so children are written in local coordinates |
+| `onMove` | `(transform: GrabResultTransform) => void` | - | Receives the new pose when released/committed (Required). Reflect it in state to update `transform` |
+| `renderGhost` | `() => ReactNode` | - | Returns the ghost (semi-transparent, no physics) shown while grabbing, in local coordinates. Falls back to `children` if omitted |
+| `enabled` | `boolean` | `true` | Whether it is grabbable (`false` to temporarily disable) |
+| `children` | `ReactNode` | - | The grabbable object (written in local coordinates, Required) |
+
+#### GrabbableTransform / GrabResultTransform
+
+```typescript
+interface GrabbableTransform {
+  position: { x: number; y: number; z: number };  // World coordinates
+  rotation: { x: number; y: number; z: number };  // Euler angles (radians)
+  scale?: number;                                   // Uniform scale (defaults to 1)
+}
+
+interface GrabResultTransform {
+  position: { x: number; y: number; z: number };
+  rotation: { x: number; y: number; z: number };
+}
+```
+
+:::caution[When including physics]
+If children include physics (such as `RigidBody`), you must provide a **physics-free** version via `renderGhost`. Otherwise `children` is rendered as the ghost directly, and the collider of the real object and the ghost overlap while grabbing.
+:::
+
+:::note[Controls]
+Grabbing assumes desktop (pointer lock + center crosshair). In `DevEnvironment`, press **G** to grab/place, use the mouse wheel to adjust distance, click to commit, and **Esc** (releasing pointer lock) to cancel.
+:::
+
+---
+
 ### Mirror
 
 Creates a real-time reflective surface.
@@ -452,6 +520,7 @@ Clipping distances configurable via the `camera` prop. Corresponds to the `world
 - **First-Person Player**: Physics-based WASD movement, jumping, and respawning
 - **View Controls**: View manipulation via PointerLockControls
 - **Interaction**: Raycasting to INTERACTABLE layer + click interaction
+- **Grabbing (Grabbable)**: Raycasting to GRABBABLE layer + following the view and committing
 - **Crosshair UI**: Center-screen crosshair (highlights on hit)
 - **Guide UI**: Pointer lock state guidance UI
 - **Controls Help UI**: UI displaying control instructions
@@ -460,10 +529,12 @@ Clipping distances configurable via the `camera` prop. Corresponds to the `world
 
 | Input | Description |
 |-------|-------------|
-| Click | Start pointer lock / Interact |
+| Click | Start pointer lock / Interact / Commit while grabbing |
 | WASD / Arrow Keys | Movement |
 | Space / E | Jump |
-| ESC | Release pointer lock |
+| G | Grab / Place (`Grabbable` targets) |
+| Mouse Wheel | Adjust distance while grabbing |
+| ESC | Release pointer lock (cancels while grabbing) |
 
 :::note[Prerequisites]
 Installation of `@react-three/rapier` (`^2.0.0`) is required (optional peerDependency).
@@ -1549,12 +1620,13 @@ import { LAYERS } from '@xrift/world-components';
 | `LAYERS.FIRST_PERSON_ONLY` | `9` | First-person view only (for VRMFirstPerson) |
 | `LAYERS.THIRD_PERSON_ONLY` | `10` | Third-person view only (for VRMFirstPerson) |
 | `LAYERS.INTERACTABLE` | `11` | Interactable objects (Raycast targets) |
+| `LAYERS.GRABBABLE` | `14` | Grabbable objects (Raycast targets for `Grabbable`) |
 
 #### Related Types
 
 ```typescript
-type LayerName = 'DEFAULT' | 'FIRST_PERSON_ONLY' | 'THIRD_PERSON_ONLY' | 'INTERACTABLE';
-type LayerNumber = 0 | 9 | 10 | 11;
+type LayerName = 'DEFAULT' | 'FIRST_PERSON_ONLY' | 'THIRD_PERSON_ONLY' | 'INTERACTABLE' | 'GRABBABLE';
+type LayerNumber = 0 | 9 | 10 | 11 | 14;
 ```
 
 #### Use Cases


### PR DESCRIPTION
## 概要

`@xrift/world-components` に追加された `<Grabbable>` コンポーネント（WebXR-JP/xrift-world-components#179）のドキュメントを追加します。

## 変更内容

`docs/world-components/components/index.md`（ja）と英語版 i18n の両方を更新:

- **Grabbable コンポーネント**を Interactable の直後に追加
  - 使い方サンプル、Props 表、`GrabbableTransform` / `GrabResultTransform` 型
  - 物理を含む場合の `renderGhost` 指定に関する注意（caution）
  - 操作方法（G / ホイール / クリック / Esc）の note
- **LAYERS** 表に `GRABBABLE` (14) を追記、関連する型も更新
- **DevEnvironment** の「提供する機能」「操作方法」に掴む操作を追記

## 検証

- [x] `npm run build`（ja / en 両方 Compiled successfully）

🤖 Generated with [Claude Code](https://claude.com/claude-code)