### PR TITLE
docs: useWorldStorage の追加と useSharedFile のロック・メタデータ対応を反映

### DIFF
--- a/docs/world-components/components/index.md
+++ b/docs/world-components/components/index.md
@@ -1464,19 +1464,21 @@ VRセッション中にファイル選択がリクエストされた場合、自
 
 ### useSharedFile
 
-インスタンスの共有ファイルをアップロード・一覧取得するフックです。3D空間内から画像やドキュメントをアップロードし、他のユーザーと共有できます。
+インスタンスの共有ファイルをアップロード・一覧取得・ロック（削除保護）・情報更新するフックです。3D空間内から画像やドキュメントをアップロードし、他のユーザーと共有できます。
 
 ```tsx
 import { useSharedFile } from '@xrift/world-components';
 
 function MyComponent() {
-  const { uploadSharedFile, getSharedFiles } = useSharedFile();
+  const { uploadSharedFile, getSharedFiles, setSharedFileLock, updateSharedFile } = useSharedFile();
 
   const handleUpload = async (file: File) => {
     const result = await uploadSharedFile(file, (progress) => {
       console.log(`${progress}%`);
     });
     console.log('URL:', result.publicUrl);
+    // アップロード直後にロックして誤削除を防ぐ
+    await setSharedFileLock(result.id, true);
   };
 }
 ```
@@ -1485,8 +1487,10 @@ function MyComponent() {
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `uploadSharedFile` | `(file: File, onProgress?: (progress: number) => void) => Promise<SharedFileInfo>` | ファイルをアップロードする |
+| `uploadSharedFile` | `(file: File, onProgress?: (progress: number) => void, options?: UploadSharedFileOptions) => Promise<SharedFileInfo>` | ファイルをアップロードする |
 | `getSharedFiles` | `() => Promise<SharedFileInfo[]>` | 共有ファイル一覧を取得する |
+| `setSharedFileLock` | `(fileId: string, locked: boolean) => Promise<SharedFileInfo>` | ロック状態（削除保護）を設定する |
+| `updateSharedFile` | `(fileId: string, updates: UpdateSharedFileParams) => Promise<SharedFileInfo>` | ファイル情報（fileName / description / metadata）を更新する |
 
 #### SharedFileInfo
 
@@ -1497,7 +1501,33 @@ function MyComponent() {
 | `contentType` | `string` | MIMEタイプ |
 | `fileSize` | `number` | ファイルサイズ（バイト） |
 | `publicUrl` | `string` | 公開URL |
+| `locked` | `boolean` | ロック中（削除保護）かどうか |
+| `description` | `string \| null` | 説明文 |
+| `metadata` | `Record<string, string> \| null` | 構造化メタデータ |
 | `createdAt` | `string` | 作成日時（ISO 8601） |
+
+#### UploadSharedFileOptions
+
+アップロード時に任意で付与できる情報です。
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `description` | `string` | 説明文（500文字以内） |
+| `metadata` | `Record<string, string>` | フラットな key-value のメタデータ（20件以内、キー1〜64文字、値500文字以内） |
+
+#### UpdateSharedFileParams
+
+`updateSharedFile` に渡す更新内容です。`description` / `metadata` は `null` を指定するとクリアできます。
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `fileName` | `string` | ファイル名 |
+| `description` | `string \| null` | 説明文（`null` でクリア） |
+| `metadata` | `Record<string, string> \| null` | メタデータ（`null` でクリア） |
+
+:::note
+ロック中（`locked: true`）のファイルは削除できず、`updateSharedFile` による更新も拒否されます。更新したい場合は先に `setSharedFileLock(fileId, false)` でロックを解除してください。
+:::
 
 #### 使用例
 
@@ -1556,6 +1586,40 @@ function SharedFileUploader() {
 }
 ```
 
+##### 説明文・メタデータ付きアップロードとロック
+
+来場者がアップロードしたファイルを永続展示するようなケースでは、アップロード時に説明文・メタデータを付与し、直後にロックすることで誤削除を防げます。
+
+```tsx
+import { useSharedFile } from '@xrift/world-components'
+
+function ExhibitUploader() {
+  const { uploadSharedFile, setSharedFileLock, updateSharedFile } = useSharedFile()
+
+  const handleExhibitUpload = async (file: File) => {
+    // 説明文・メタデータを付与してアップロード
+    const result = await uploadSharedFile(file, undefined, {
+      description: '展示品A',
+      metadata: { exhibit: 'pedestal-1' },
+    })
+
+    // アップロード直後にロックして誤削除を防ぐ
+    await setSharedFileLock(result.id, true)
+
+    return result.publicUrl
+  }
+
+  const handleUpdateDescription = async (fileId: string) => {
+    // ロック中は更新できないため、一度解除してから更新して再ロック
+    await setSharedFileLock(fileId, false)
+    await updateSharedFile(fileId, { description: '展示品B' })
+    await setSharedFileLock(fileId, true)
+  }
+
+  // ...
+}
+```
+
 ---
 
 ### useItem
@@ -1600,6 +1664,141 @@ function VotingBox() {
   );
 }
 ```
+
+---
+
+### useWorldStorage
+
+ワールド単位のKV永続化（World Storage）を提供するフックです。ランキング・ワールド内通貨・登録情報などを、インスタンスをまたいで永続化できます。
+
+```tsx
+import { useWorldStorage } from '@xrift/world-components';
+
+function MyComponent() {
+  const storage = useWorldStorage();
+
+  const saveProgress = async () => {
+    // 共有KV（ワールドに1つの共有値）
+    await storage.shared.set('event_phase', '第2章');
+    const visits = await storage.shared.increment('total_visits', 1);
+
+    // ユーザー別KV（書き込みは自分の値のみ）
+    await storage.player.set('coins', 340);
+    const coins = await storage.player.get('coins');
+  };
+}
+```
+
+#### 戻り値
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `shared` | `SharedWorldStorage` | 共有KV（ワールドに1つの共有値）。インスタンス参加中の認証ユーザーなら誰でも書ける |
+| `player` | `PlayerWorldStorage` | ユーザー別KV。書き込みは自分の値のみ、読み取りは他人の値も可 |
+
+#### SharedWorldStorage
+
+| Method | Type | Description |
+|--------|------|-------------|
+| `get` | `(key: string) => Promise<unknown>` | 値を取得する。存在しない場合は `undefined` |
+| `list` | `() => Promise<WorldStorageEntry[]>` | すべてのキーと値を取得する |
+| `set` | `(key: string, value: unknown) => Promise<void>` | 値を保存する |
+| `increment` | `(key: string, delta: number) => Promise<number>` | 数値を加算し、加算後の値を返す（同時実行でも加算がロストしない） |
+| `delete` | `(key: string) => Promise<void>` | 値を削除する（冪等） |
+
+#### PlayerWorldStorage
+
+| Method | Type | Description |
+|--------|------|-------------|
+| `get` | `(key: string, options?: { userId?: string }) => Promise<unknown>` | 値を取得する。`userId` を指定すると他のユーザーの値を読める |
+| `list` | `(options?: { userId?: string }) => Promise<WorldStorageEntry[]>` | すべてのキーと値を取得する。`userId` 指定で他のユーザーの値も可 |
+| `set` | `(key: string, value: unknown) => Promise<void>` | 自分の値を保存する |
+| `increment` | `(key: string, delta: number) => Promise<number>` | 自分の値に数値を加算し、加算後の値を返す |
+| `delete` | `(key: string) => Promise<void>` | 自分の値を削除する（冪等） |
+
+#### 制約・指針
+
+| 項目 | 内容 |
+|------|------|
+| 保存タイミング | 「ゲームイベントの節目」で保存する。毎フレームの同期は `useInstanceState` などの揮発性の状態同期を使う |
+| 容量 | ワールドごと合計 10MB / 1エントリ 100KB |
+| キー数 | 共有 256キー / ユーザーあたり 64キー |
+| キー形式 | `/^[A-Za-z0-9_.\-:]{1,128}$/` |
+| レートリミット | 書き込みはユーザーごと 30回/分 |
+| 読み取り | 公開（認証不要で API から読める）。**秘密情報を入れないこと** |
+| ゲスト | 読み取りのみ（書き込みは `WorldStorageError` になる） |
+| 加算 | 通貨・スコアの加算は `set` ではなく `increment` を使う |
+
+#### WorldStorageError
+
+操作が失敗すると `WorldStorageError` が投げられます。`code` プロパティで原因を判別できます。
+
+| Code | Description |
+|------|-------------|
+| `QUOTA_EXCEEDED` | ワールド合計容量（10MB）を超過 |
+| `LIMIT_EXCEEDED` | キー数上限を超過（共有: 256キー / ユーザーあたり: 64キー） |
+| `ENTRY_TOO_LARGE` | 1エントリの上限（100KB）を超過 |
+| `TYPE_MISMATCH` | `increment` 対象の既存値が数値でない |
+| `INVALID_KEY` | キー形式が不正 |
+| `NOT_IN_WORLD` | ワールドのインスタンスに参加していない状態での書き込み |
+| `RATE_LIMITED` | レートリミット超過 |
+| `UNAUTHORIZED` | 未認証（ゲスト）での書き込み |
+| `UNKNOWN` | その他のエラー |
+
+#### 使用例
+
+##### 来場者数カウンター
+
+```tsx
+import { useWorldStorage, Interactable } from '@xrift/world-components'
+import { Text } from '@react-three/drei'
+import { useEffect, useState } from 'react'
+
+function VisitCounter() {
+  const storage = useWorldStorage()
+  const [visits, setVisits] = useState<number | null>(null)
+
+  useEffect(() => {
+    // 入場時に一度だけカウントアップ
+    storage.shared.increment('total_visits', 1).then(setVisits)
+  }, [storage])
+
+  return (
+    <Text position={[0, 2, 0]} fontSize={0.2} color="white">
+      {visits === null ? '...' : `累計来場者数: ${visits}`}
+    </Text>
+  )
+}
+```
+
+##### ユーザー別のコイン管理
+
+```tsx
+import { useWorldStorage, WorldStorageError } from '@xrift/world-components'
+
+function useCoins() {
+  const storage = useWorldStorage()
+
+  const addCoins = async (amount: number) => {
+    try {
+      // 同時実行でも加算がロストしないよう increment を使う
+      return await storage.player.increment('coins', amount)
+    } catch (e) {
+      if (e instanceof WorldStorageError && e.code === 'UNAUTHORIZED') {
+        console.log('ゲストは書き込みできません')
+        return null
+      }
+      throw e
+    }
+  }
+
+  return { addCoins }
+}
+```
+
+:::note
+World Storage は永続化ストレージです。毎フレーム更新されるような値の同期には `useInstanceState` / `useInstanceEvent` を使い、World Storage への保存はゲームイベントの節目（クリア時、購入時など）に行ってください。
+:::
 
 ---
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/world-components/components/index.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/world-components/components/index.md
@@ -1469,19 +1469,21 @@ When a file input is requested during a VR session, the VR session is automatica
 
 ### useSharedFile
 
-A hook for uploading and listing shared files within an instance. Allows uploading images and documents from within the 3D space for sharing with other users.
+A hook for uploading, listing, locking (deletion protection), and updating shared files within an instance. Allows uploading images and documents from within the 3D space for sharing with other users.
 
 ```tsx
 import { useSharedFile } from '@xrift/world-components';
 
 function MyComponent() {
-  const { uploadSharedFile, getSharedFiles } = useSharedFile();
+  const { uploadSharedFile, getSharedFiles, setSharedFileLock, updateSharedFile } = useSharedFile();
 
   const handleUpload = async (file: File) => {
     const result = await uploadSharedFile(file, (progress) => {
       console.log(`${progress}%`);
     });
     console.log('URL:', result.publicUrl);
+    // Lock right after upload to prevent accidental deletion
+    await setSharedFileLock(result.id, true);
   };
 }
 ```
@@ -1490,8 +1492,10 @@ function MyComponent() {
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `uploadSharedFile` | `(file: File, onProgress?: (progress: number) => void) => Promise<SharedFileInfo>` | Upload a file |
+| `uploadSharedFile` | `(file: File, onProgress?: (progress: number) => void, options?: UploadSharedFileOptions) => Promise<SharedFileInfo>` | Upload a file |
 | `getSharedFiles` | `() => Promise<SharedFileInfo[]>` | Get the list of shared files |
+| `setSharedFileLock` | `(fileId: string, locked: boolean) => Promise<SharedFileInfo>` | Set the lock state (deletion protection) |
+| `updateSharedFile` | `(fileId: string, updates: UpdateSharedFileParams) => Promise<SharedFileInfo>` | Update file info (fileName / description / metadata) |
 
 #### SharedFileInfo
 
@@ -1502,7 +1506,33 @@ function MyComponent() {
 | `contentType` | `string` | MIME type |
 | `fileSize` | `number` | File size in bytes |
 | `publicUrl` | `string` | Public URL |
+| `locked` | `boolean` | Whether the file is locked (deletion protection) |
+| `description` | `string \| null` | Description text |
+| `metadata` | `Record<string, string> \| null` | Structured metadata |
 | `createdAt` | `string` | Creation date (ISO 8601) |
+
+#### UploadSharedFileOptions
+
+Optional information that can be attached at upload time.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `description` | `string` | Description text (up to 500 characters) |
+| `metadata` | `Record<string, string>` | Flat key-value metadata (up to 20 entries, keys 1-64 characters, values up to 500 characters) |
+
+#### UpdateSharedFileParams
+
+Update payload for `updateSharedFile`. Pass `null` for `description` / `metadata` to clear them.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `fileName` | `string` | File name |
+| `description` | `string \| null` | Description text (`null` to clear) |
+| `metadata` | `Record<string, string> \| null` | Metadata (`null` to clear) |
+
+:::note
+A locked file (`locked: true`) cannot be deleted, and updates via `updateSharedFile` are also rejected. To update a locked file, unlock it first with `setSharedFileLock(fileId, false)`.
+:::
 
 #### Usage Examples
 
@@ -1561,6 +1591,40 @@ function SharedFileUploader() {
 }
 ```
 
+##### Upload with Description / Metadata and Lock
+
+For use cases like permanently exhibiting visitor-uploaded files, attach a description and metadata at upload time, then lock the file immediately to prevent accidental deletion.
+
+```tsx
+import { useSharedFile } from '@xrift/world-components'
+
+function ExhibitUploader() {
+  const { uploadSharedFile, setSharedFileLock, updateSharedFile } = useSharedFile()
+
+  const handleExhibitUpload = async (file: File) => {
+    // Upload with description and metadata
+    const result = await uploadSharedFile(file, undefined, {
+      description: 'Exhibit A',
+      metadata: { exhibit: 'pedestal-1' },
+    })
+
+    // Lock right after upload to prevent accidental deletion
+    await setSharedFileLock(result.id, true)
+
+    return result.publicUrl
+  }
+
+  const handleUpdateDescription = async (fileId: string) => {
+    // Locked files cannot be updated: unlock, update, then re-lock
+    await setSharedFileLock(fileId, false)
+    await updateSharedFile(fileId, { description: 'Exhibit B' })
+    await setSharedFileLock(fileId, true)
+  }
+
+  // ...
+}
+```
+
 ---
 
 ### useItem
@@ -1603,6 +1667,141 @@ function VotingBox() {
   );
 }
 ```
+
+---
+
+### useWorldStorage
+
+A hook that provides world-scoped persistent key-value storage (World Storage). Persist rankings, in-world currency, registration data, and more across instances.
+
+```tsx
+import { useWorldStorage } from '@xrift/world-components';
+
+function MyComponent() {
+  const storage = useWorldStorage();
+
+  const saveProgress = async () => {
+    // Shared KV (one shared value per world)
+    await storage.shared.set('event_phase', 'chapter-2');
+    const visits = await storage.shared.increment('total_visits', 1);
+
+    // Per-player KV (you can only write your own values)
+    await storage.player.set('coins', 340);
+    const coins = await storage.player.get('coins');
+  };
+}
+```
+
+#### Return Value
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `shared` | `SharedWorldStorage` | Shared KV (one shared value per world). Any authenticated user in the instance can write |
+| `player` | `PlayerWorldStorage` | Per-player KV. Writes are limited to your own values; reads can access other users' values |
+
+#### SharedWorldStorage
+
+| Method | Type | Description |
+|--------|------|-------------|
+| `get` | `(key: string) => Promise<unknown>` | Get a value. Returns `undefined` if it does not exist |
+| `list` | `() => Promise<WorldStorageEntry[]>` | Get all keys and values |
+| `set` | `(key: string, value: unknown) => Promise<void>` | Save a value |
+| `increment` | `(key: string, delta: number) => Promise<number>` | Add to a numeric value and return the result (no lost updates under concurrency) |
+| `delete` | `(key: string) => Promise<void>` | Delete a value (idempotent) |
+
+#### PlayerWorldStorage
+
+| Method | Type | Description |
+|--------|------|-------------|
+| `get` | `(key: string, options?: { userId?: string }) => Promise<unknown>` | Get a value. Pass `userId` to read another user's value |
+| `list` | `(options?: { userId?: string }) => Promise<WorldStorageEntry[]>` | Get all keys and values. Pass `userId` to read another user's values |
+| `set` | `(key: string, value: unknown) => Promise<void>` | Save your own value |
+| `increment` | `(key: string, delta: number) => Promise<number>` | Add to your own numeric value and return the result |
+| `delete` | `(key: string) => Promise<void>` | Delete your own value (idempotent) |
+
+#### Constraints and Guidelines
+
+| Item | Details |
+|------|---------|
+| When to save | Save at game-event milestones. For per-frame sync, use volatile state sync such as `useInstanceState` |
+| Capacity | 10MB total per world / 100KB per entry |
+| Key count | 256 shared keys / 64 keys per user |
+| Key format | `/^[A-Za-z0-9_.\-:]{1,128}$/` |
+| Rate limit | Writes are limited to 30 per minute per user |
+| Reads | Public (readable via API without authentication). **Never store secrets** |
+| Guests | Read-only (writes throw a `WorldStorageError`) |
+| Addition | For currency / scores, use `increment` instead of `set` |
+
+#### WorldStorageError
+
+Failed operations throw a `WorldStorageError`. Use the `code` property to determine the cause.
+
+| Code | Description |
+|------|-------------|
+| `QUOTA_EXCEEDED` | Total world capacity (10MB) exceeded |
+| `LIMIT_EXCEEDED` | Key count limit exceeded (shared: 256 keys / per user: 64 keys) |
+| `ENTRY_TOO_LARGE` | Entry size limit (100KB) exceeded |
+| `TYPE_MISMATCH` | The existing value targeted by `increment` is not a number |
+| `INVALID_KEY` | Invalid key format |
+| `NOT_IN_WORLD` | Writing while not in a world instance |
+| `RATE_LIMITED` | Rate limit exceeded |
+| `UNAUTHORIZED` | Writing while unauthenticated (guest) |
+| `UNKNOWN` | Other errors |
+
+#### Usage Examples
+
+##### Visit Counter
+
+```tsx
+import { useWorldStorage, Interactable } from '@xrift/world-components'
+import { Text } from '@react-three/drei'
+import { useEffect, useState } from 'react'
+
+function VisitCounter() {
+  const storage = useWorldStorage()
+  const [visits, setVisits] = useState<number | null>(null)
+
+  useEffect(() => {
+    // Count up once on entry
+    storage.shared.increment('total_visits', 1).then(setVisits)
+  }, [storage])
+
+  return (
+    <Text position={[0, 2, 0]} fontSize={0.2} color="white">
+      {visits === null ? '...' : `Total visits: ${visits}`}
+    </Text>
+  )
+}
+```
+
+##### Per-Player Coin Management
+
+```tsx
+import { useWorldStorage, WorldStorageError } from '@xrift/world-components'
+
+function useCoins() {
+  const storage = useWorldStorage()
+
+  const addCoins = async (amount: number) => {
+    try {
+      // Use increment so concurrent additions are not lost
+      return await storage.player.increment('coins', amount)
+    } catch (e) {
+      if (e instanceof WorldStorageError && e.code === 'UNAUTHORIZED') {
+        console.log('Guests cannot write')
+        return null
+      }
+      throw e
+    }
+  }
+
+  return { addCoins }
+}
+```
+
+:::note
+World Storage is persistent storage. For values that change every frame, use `useInstanceState` / `useInstanceEvent` for synchronization, and save to World Storage only at game-event milestones (e.g. on clear, on purchase).
+:::
 
 ---
 


### PR DESCRIPTION
## 概要

world-components に最近追加された機能をドキュメントに反映します（日本語・英語両方）。

対象機能:
- WebXR-JP/xrift-world-components#185 `useWorldStorage`（ワールド単位のKV永続化）
- WebXR-JP/xrift-world-components#187 `setSharedFileLock`（共有ファイルのロック操作）
- WebXR-JP/xrift-world-components#188 共有ファイルの `description` / `metadata` 対応

## 変更内容

### useWorldStorage セクションを新規追加
- `shared` / `player` KV の各メソッド一覧
- 制約・指針（容量 10MB / エントリ 100KB / キー数 / キー形式 / レートリミット / 公開読み取り / ゲスト読み取り専用）
- `WorldStorageError` のエラーコード一覧
- 使用例（来場者数カウンター・ユーザー別コイン管理）

### useSharedFile セクションを更新
- 戻り値に `setSharedFileLock` / `updateSharedFile` を追記
- `SharedFileInfo` に `locked` / `description` / `metadata` を追記
- `UploadSharedFileOptions` / `UpdateSharedFileParams` の説明を追加
- ロック中は削除・更新が拒否される旨の note を追加
- 説明文・メタデータ付きアップロード + ロックの使用例を追加

## 確認

- `npm run build` 通過（日英両ロケール）

🤖 Generated with [Claude Code](https://claude.com/claude-code)