### PR TITLE
docs: useSharedFile に deleteSharedFile を追記

### DIFF
--- a/docs/world-components/components/index.md
+++ b/docs/world-components/components/index.md
@@ -1464,7 +1464,7 @@ VRセッション中にファイル選択がリクエストされた場合、自
 
 ### useSharedFile
 
-インスタンスの共有ファイルをアップロード・一覧取得・ロック（削除保護）・情報更新するフックです。3D空間内から画像やドキュメントをアップロードし、他のユーザーと共有できます。
+インスタンスの共有ファイルをアップロード・一覧取得・ロック（削除保護）・情報更新・削除するフックです。3D空間内から画像やドキュメントをアップロードし、他のユーザーと共有できます。
 
 ```tsx
 import { useSharedFile } from '@xrift/world-components';
@@ -1491,6 +1491,7 @@ function MyComponent() {
 | `getSharedFiles` | `() => Promise<SharedFileInfo[]>` | 共有ファイル一覧を取得する |
 | `setSharedFileLock` | `(fileId: string, locked: boolean) => Promise<SharedFileInfo>` | ロック状態（削除保護）を設定する |
 | `updateSharedFile` | `(fileId: string, updates: UpdateSharedFileParams) => Promise<SharedFileInfo>` | ファイル情報（fileName / description / metadata）を更新する |
+| `deleteSharedFile` | `(fileId: string) => Promise<void>` | ファイルを削除する |
 
 #### SharedFileInfo
 
@@ -1526,7 +1527,7 @@ function MyComponent() {
 | `metadata` | `Record<string, string> \| null` | メタデータ（`null` でクリア） |
 
 :::note
-ロック中（`locked: true`）のファイルは削除できず、`updateSharedFile` による更新も拒否されます。更新したい場合は先に `setSharedFileLock(fileId, false)` でロックを解除してください。
+ロック中（`locked: true`）のファイルは `deleteSharedFile` による削除も `updateSharedFile` による更新も拒否されます。削除・更新したい場合は先に `setSharedFileLock(fileId, false)` でロックを解除してください。
 :::
 
 #### 使用例
@@ -1594,7 +1595,7 @@ function SharedFileUploader() {
 import { useSharedFile } from '@xrift/world-components'
 
 function ExhibitUploader() {
-  const { uploadSharedFile, setSharedFileLock, updateSharedFile } = useSharedFile()
+  const { uploadSharedFile, setSharedFileLock, updateSharedFile, deleteSharedFile } = useSharedFile()
 
   const handleExhibitUpload = async (file: File) => {
     // 説明文・メタデータを付与してアップロード
@@ -1614,6 +1615,12 @@ function ExhibitUploader() {
     await setSharedFileLock(fileId, false)
     await updateSharedFile(fileId, { description: '展示品B' })
     await setSharedFileLock(fileId, true)
+  }
+
+  const handleRemoveExhibit = async (fileId: string) => {
+    // 展示を取り下げてファイル実体も削除（ロック中は先に解除する）
+    await setSharedFileLock(fileId, false)
+    await deleteSharedFile(fileId)
   }
 
   // ...

--- a/i18n/en/docusaurus-plugin-content-docs/current/world-components/components/index.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/world-components/components/index.md
@@ -1469,7 +1469,7 @@ When a file input is requested during a VR session, the VR session is automatica
 
 ### useSharedFile
 
-A hook for uploading, listing, locking (deletion protection), and updating shared files within an instance. Allows uploading images and documents from within the 3D space for sharing with other users.
+A hook for uploading, listing, locking (deletion protection), updating, and deleting shared files within an instance. Allows uploading images and documents from within the 3D space for sharing with other users.
 
 ```tsx
 import { useSharedFile } from '@xrift/world-components';
@@ -1496,6 +1496,7 @@ function MyComponent() {
 | `getSharedFiles` | `() => Promise<SharedFileInfo[]>` | Get the list of shared files |
 | `setSharedFileLock` | `(fileId: string, locked: boolean) => Promise<SharedFileInfo>` | Set the lock state (deletion protection) |
 | `updateSharedFile` | `(fileId: string, updates: UpdateSharedFileParams) => Promise<SharedFileInfo>` | Update file info (fileName / description / metadata) |
+| `deleteSharedFile` | `(fileId: string) => Promise<void>` | Delete a file |
 
 #### SharedFileInfo
 
@@ -1531,7 +1532,7 @@ Update payload for `updateSharedFile`. Pass `null` for `description` / `metadata
 | `metadata` | `Record<string, string> \| null` | Metadata (`null` to clear) |
 
 :::note
-A locked file (`locked: true`) cannot be deleted, and updates via `updateSharedFile` are also rejected. To update a locked file, unlock it first with `setSharedFileLock(fileId, false)`.
+A locked file (`locked: true`) rejects both deletion via `deleteSharedFile` and updates via `updateSharedFile`. To delete or update a locked file, unlock it first with `setSharedFileLock(fileId, false)`.
 :::
 
 #### Usage Examples
@@ -1599,7 +1600,7 @@ For use cases like permanently exhibiting visitor-uploaded files, attach a descr
 import { useSharedFile } from '@xrift/world-components'
 
 function ExhibitUploader() {
-  const { uploadSharedFile, setSharedFileLock, updateSharedFile } = useSharedFile()
+  const { uploadSharedFile, setSharedFileLock, updateSharedFile, deleteSharedFile } = useSharedFile()
 
   const handleExhibitUpload = async (file: File) => {
     // Upload with description and metadata
@@ -1619,6 +1620,12 @@ function ExhibitUploader() {
     await setSharedFileLock(fileId, false)
     await updateSharedFile(fileId, { description: 'Exhibit B' })
     await setSharedFileLock(fileId, true)
+  }
+
+  const handleRemoveExhibit = async (fileId: string) => {
+    // Remove the exhibit and delete the file itself (unlock first)
+    await setSharedFileLock(fileId, false)
+    await deleteSharedFile(fileId)
   }
 
   // ...


### PR DESCRIPTION
## 概要

WebXR-JP/xrift-world-components#191（v0.45.0）で追加された共有ファイルの削除 API `deleteSharedFile` をドキュメントに反映します（日本語・英語両方）。

## 変更内容

- `useSharedFile` の戻り値一覧に `deleteSharedFile(fileId: string): Promise<void>` を追加
- ロック中のファイルは削除・更新とも拒否される旨に note を更新
- 展示ユースケースの使用例に「ロック解除 → 削除」のパターンを追加

## 確認

- `npm run build` 通過（日英両ロケール）

🤖 Generated with [Claude Code](https://claude.com/claude-code)