### PR TITLE
docs: ScreenShareDisplay の placeholderImageUrl を追記（v0.46.0）

### DIFF
--- a/docs/world-components/components/index.md
+++ b/docs/world-components/components/index.md
@@ -245,9 +245,16 @@ import { ScreenShareDisplay } from '@xrift/world-components';
 | `rotation` | `[number, number, number]` | `[0, 0, 0]` | スクリーンの回転 |
 | `width` | `number` | `4` | スクリーンの幅（高さは16:9で自動計算） |
 | `targetFps` | `number` | - | テクスチャ更新のターゲットFPS |
+| `placeholderImageUrl` | `string` | - | 未共有時に表示するプレースホルダー画像のURL |
 
 :::tip[アスペクト比の維持]
 映像のアスペクト比は自動的に維持されます。16:9以外の映像でも黒帯が入り正しく表示されます。
+:::
+
+:::tip[プレースホルダー画像]
+`placeholderImageUrl` を指定すると、画面共有していない間、指定した画像をスクリーンに表示できます。画像はスクリーン内に収まるように表示され（contain）、読み込みに失敗した場合は背景色とガイドテキストの表示にフォールバックします。
+
+画像はWebGLテクスチャとして読み込むため、CORS を許可している画像URLを指定してください（xrift にアップロードした画像はそのまま使えます）。
 :::
 
 :::note[制限事項]

--- a/i18n/en/docusaurus-plugin-content-docs/current/world-components/components/index.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/world-components/components/index.md
@@ -268,9 +268,16 @@ import { ScreenShareDisplay } from '@xrift/world-components';
 | `rotation` | `[number, number, number]` | `[0, 0, 0]` | Rotation of the screen |
 | `width` | `number` | `4` | Width of the screen (Height is automatically calculated at 16:9) |
 | `targetFps` | `number` | - | Texture update FPS limit for low-spec devices (unlimited when omitted) |
+| `placeholderImageUrl` | `string` | - | URL of a placeholder image shown while no screen is being shared |
 
 :::tip[Maintaining Aspect Ratio]
 The aspect ratio of the video is automatically maintained. Video other than 16:9 will be displayed correctly with black bars.
+:::
+
+:::tip[Placeholder Image]
+When `placeholderImageUrl` is specified, the image is displayed on the screen while no screen is being shared. The image is fitted inside the screen (contain), and if loading fails, the display falls back to the background color and guide text.
+
+Since the image is loaded as a WebGL texture, specify an image URL that allows CORS (images uploaded to xrift work as-is).
 :::
 
 :::note[Limitations]


### PR DESCRIPTION
## 概要
[xrift-world-components v0.46.0](https://github.com/WebXR-JP/xrift-world-components/pull/192) で追加された `ScreenShareDisplay` の `placeholderImageUrl` prop をドキュメントに追記しました（日本語・英語）。

## 変更内容
- Props テーブルに `placeholderImageUrl` の行を追加
- プレースホルダー画像の挙動（contain 表示、読み込み失敗時のフォールバック）と CORS の注意点を tip として追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)